### PR TITLE
[PIRK-2] Enhance Pallier acquisition of PRNG provider.

### DIFF
--- a/src/main/java/org/apache/pirk/encryption/Paillier.java
+++ b/src/main/java/org/apache/pirk/encryption/Paillier.java
@@ -69,6 +69,20 @@ public class Paillier implements Serializable
   private static final long serialVersionUID = 1L;
 
   private static Logger logger = LogUtils.getLoggerForThisClass();
+  
+  private static final SecureRandom nativePRNGSecureRandom;
+  
+  static
+  {
+    try
+    {
+      nativePRNGSecureRandom = SecureRandom.getInstance("NativePRNG");
+    } catch (Exception e)
+    {
+      logger.error("Unable to instantiate a SecureRandom object with the NativePRNG algorithm.", e);
+      throw new RuntimeException("Unable to instantiate a SecureRandom object with the NativePRNG algorithm.", e);
+    }
+  }
 
   BigInteger p = null; // large prime
   BigInteger q = null; // large prime
@@ -222,18 +236,6 @@ public class Paillier implements Serializable
 
   private void getKeys(int certainty)
   {
-    SecureRandom nativePRNGSecureRandom = null;
-    try
-    {
-      nativePRNGSecureRandom = SecureRandom.getInstance("NativePRNG", "SUN");
-    } catch (Exception e)
-    {
-      logger.error("Unable to instantiate a SecureRandom object from the SUN provider with the NativePRNG algorithm!");
-      e.printStackTrace();
-      // If we can't generate good random using a method we are confident in, we shouldn't continue
-      System.exit(1);
-    }
-
     // Generate the primes
     BigInteger[] pq = PrimeGenerator.getPrimePair(bitLength, certainty, nativePRNGSecureRandom);
     p = pq[0];
@@ -258,19 +260,6 @@ public class Paillier implements Serializable
    */
   public BigInteger encrypt(BigInteger m) throws PIRException
   {
-    BigInteger cipher = null;
-    SecureRandom nativePRNGSecureRandom = null;
-    try
-    {
-      nativePRNGSecureRandom = SecureRandom.getInstance("NativePRNG", "SUN");
-    } catch (Exception e)
-    {
-      logger.error("Unable to instantiate a SecureRandom object from the SUN provider with the NativePRNG algorithm!");
-      e.printStackTrace();
-      // If we can't generate good random using a method we are confident in, we shouldn't continue
-      System.exit(1);
-    }
-
     // Generate a random value r in (Z/NZ)*
     BigInteger r = (new BigInteger(bitLength, nativePRNGSecureRandom)).mod(N);
     while (r.mod(p).equals(BigInteger.ZERO) || r.mod(q).equals(BigInteger.ZERO) || r.equals(BigInteger.ONE) || r.equals(BigInteger.ZERO))
@@ -278,9 +267,7 @@ public class Paillier implements Serializable
       r = (new BigInteger(bitLength, nativePRNGSecureRandom)).mod(N);
     }
 
-    cipher = encrypt(m, r);
-
-    return cipher;
+    return encrypt(m, r);
   }
 
   /**

--- a/src/main/java/org/apache/pirk/encryption/Paillier.java
+++ b/src/main/java/org/apache/pirk/encryption/Paillier.java
@@ -20,6 +20,7 @@ package org.apache.pirk.encryption;
 
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 
 import org.apache.log4j.Logger;
@@ -70,17 +71,27 @@ public class Paillier implements Serializable
 
   private static Logger logger = LogUtils.getLoggerForThisClass();
   
-  private static final SecureRandom nativePRNGSecureRandom;
+  private static final SecureRandom secureRandom;
   
   static
   {
     try
     {
-      nativePRNGSecureRandom = SecureRandom.getInstance("NativePRNG");
-    } catch (Exception e)
+      String alg = SystemConfiguration.getProperty("pallier.secureRandom.algorithm");
+      if (alg == null)
+      {
+        secureRandom = new SecureRandom();
+      }
+      else
+      {
+        String provider = SystemConfiguration.getProperty("pallier.secureRandom.provider");
+        secureRandom = (provider == null) ? SecureRandom.getInstance(alg) : SecureRandom.getInstance(alg, provider);
+      }
+      logger.info("Using secure random from " + secureRandom.getProvider().getName() + ":" + secureRandom.getAlgorithm());
+    } catch (GeneralSecurityException e)
     {
-      logger.error("Unable to instantiate a SecureRandom object with the NativePRNG algorithm.", e);
-      throw new RuntimeException("Unable to instantiate a SecureRandom object with the NativePRNG algorithm.", e);
+      logger.error("Unable to instantiate a SecureRandom object with the requested algorithm.", e);
+      throw new RuntimeException("Unable to instantiate a SecureRandom object with the requested algorithm.", e);
     }
   }
 
@@ -237,7 +248,7 @@ public class Paillier implements Serializable
   private void getKeys(int certainty)
   {
     // Generate the primes
-    BigInteger[] pq = PrimeGenerator.getPrimePair(bitLength, certainty, nativePRNGSecureRandom);
+    BigInteger[] pq = PrimeGenerator.getPrimePair(bitLength, certainty, secureRandom);
     p = pq[0];
     q = pq[1];
 
@@ -261,10 +272,10 @@ public class Paillier implements Serializable
   public BigInteger encrypt(BigInteger m) throws PIRException
   {
     // Generate a random value r in (Z/NZ)*
-    BigInteger r = (new BigInteger(bitLength, nativePRNGSecureRandom)).mod(N);
+    BigInteger r = (new BigInteger(bitLength, secureRandom)).mod(N);
     while (r.mod(p).equals(BigInteger.ZERO) || r.mod(q).equals(BigInteger.ZERO) || r.equals(BigInteger.ONE) || r.equals(BigInteger.ZERO))
     {
-      r = (new BigInteger(bitLength, nativePRNGSecureRandom)).mod(N);
+      r = (new BigInteger(bitLength, secureRandom)).mod(N);
     }
 
     return encrypt(m, r);

--- a/src/main/resources/pirk.properties
+++ b/src/main/resources/pirk.properties
@@ -157,6 +157,12 @@ paillier.GMPConstantTimeMode = false
 # These checks slow down prime generation considerably
 pallier.FIPSPrimeGenerationChecks = true
 
+## These properties control the secure random number generator algorithm and provider.
+## You can specify just the algorithm, or both algorithm and provider.  The system's
+## default secure random is used when the algorithm is left unspecified. 
+pallier.secureRandom.algorithm=NativePRNG
+#pallier.secureRandom.provider=SUN
+
 ##
 ## Properties for PIR query and response
 ##


### PR DESCRIPTION
As suggested, this moves the spec for the secure random into the Pirk properties file.
Note that I have left the provider commented out at the moment, to ensure it works on a broad selection of Java runtimes, and is as close to the original code intent as possible.

In production users would likely specify a secure system PRNG, or specify both algorithm and provider in the Pirk properties file.  Therefore I would not object to commenting out both properties by default ;-)
