### PR TITLE
[PIRK-9] Exclude Travis directives from RAT checks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 /.settings/
 /.project
 /.classpath
+
+# Project runtime ignores
+/logs/

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
 				<version>0.11</version>
 				<configuration>
 					<excludes>
+                        <exclude>.travis.yml</exclude>
 						<exclude>eclipse-pirk-codestyle.xml</exclude>
 						<exclude>logs/**</exclude>
 						<exclude>docs/package-list</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
 				<version>0.11</version>
 				<configuration>
 					<excludes>
-                        <exclude>.travis.yml</exclude>
+						<exclude>.travis.yml</exclude>
 						<exclude>eclipse-pirk-codestyle.xml</exclude>
 						<exclude>logs/**</exclude>
 						<exclude>docs/package-list</exclude>


### PR DESCRIPTION
Caused a build break by conflict between adding Travis and adding RAT checks commits.
This PR simply ignores the Travis yml file from further checks.