### PR TITLE
PIRK-8

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
@@ -54,6 +54,7 @@ public class QuerierDriverCLI
   public static String PAILLIERBITSIZE = "paillierBitSize";
   public static String BITSET = "bitSet";
   public static String CERTAINTY = "certainty";
+  public static String SECURERANDOM = "pirk.securerandom.provider";
   public static String QUERYNAME = "queryName";
   public static String QUERYSCHEMAS = "querySchemas";
   public static String DATASCHEMAS = "dataSchemas";
@@ -226,6 +227,14 @@ public class QuerierDriverCLI
       }
       SystemConfiguration.setProperty(CERTAINTY, getOptionValue(CERTAINTY));
 
+      if (hasOption(SECURERANDOM))
+      {
+        String providerName = getOptionValue(SECURERANDOM);
+        SystemConfiguration.setProperty(SECURERANDOM, providerName);
+        logger.info("CLI specified secure random provider " + providerName);
+        logger.info("Existence of provider will be checked at encryption.");
+      }
+
       if (!hasOption(QUERYNAME))
       {
         logger.info("Must have the option " + QUERYNAME);
@@ -364,6 +373,13 @@ public class QuerierDriverCLI
     optionTYPE.setArgName(TYPE);
     optionTYPE.setType(String.class);
     options.addOption(optionTYPE);
+
+    // SECURERANDOM
+    Option optionSECURERANDOM = new Option("sr", SECURERANDOM, true, "required for encryption -- Name of the query");
+    optionSECURERANDOM.setRequired(false);
+    optionSECURERANDOM.setArgName(SECURERANDOM);
+    optionSECURERANDOM.setType(String.class);
+    options.addOption(optionSECURERANDOM);
 
     // NAME
     Option optionNAME = new Option("qn", QUERYNAME, true, "required for encryption -- Name of the query");

--- a/src/main/resources/pirk.properties
+++ b/src/main/resources/pirk.properties
@@ -24,7 +24,7 @@
 # Name of log4j properties file (relative to current folder)
 log4jPropertiesFile=logging/log4j.properties
 
-#Name of the local properties file - used when running with the 
+#Name of the local properties file - used when running with the
 #hadoop jar command
 local.pirk.properties=/root/local.pirk.properties
 
@@ -32,6 +32,17 @@ local.pirk.properties=/root/local.pirk.properties
 ##Spark path for SparkLauncher
 ##
 spark.home = /usr
+
+##
+## Specification of SecureRandom provider
+##
+## Allows user to specify the provider for Pirk's SecureRandom constructor. Can
+## be set here, or on the command line. Command line overrides this setting. If
+## this value is not set, it will default to the system-native provider.
+##
+
+# Name of SecureRandom provider
+pirk.securerandom.provider = none
 
 ##
 ## Data schema properties


### PR DESCRIPTION
Allows user ability to name a desired SecureRandom provider on CLI or in pirk.properties files. If provider is not on system, or if none is provided (option value "none") then Pirk will use the system default provider.