### PR TITLE
Pirk 8 - SecureRandom Alg and Provider Options to QuerierDriverCLI 

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
@@ -25,6 +25,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.log4j.Logger;
+import org.apache.pirk.querier.wideskies.QuerierConst;
 import org.apache.pirk.schema.data.LoadDataSchemas;
 import org.apache.pirk.schema.query.LoadQuerySchemas;
 import org.apache.pirk.utils.LogUtils;
@@ -60,7 +61,9 @@ public class QuerierDriverCLI
   public static String EMBEDSELECTOR = "embedSelector";
   public static String USEMEMLOOKUPTABLE = "memLookupTable";
   public static String USEHDFSLOOKUPTABLE = "useHDFSLookupTable";
-
+  public static String SR_ALGORITHM = "secureRandomAlg";
+  public static String SR_PROVIDER = "secureRandomProvider"; 
+  
   // Decryption variables
   public static String QUERIERFILE = "querierFile";
 
@@ -266,6 +269,24 @@ public class QuerierDriverCLI
       {
         SystemConfiguration.setProperty(USEHDFSLOOKUPTABLE, getOptionValue(USEHDFSLOOKUPTABLE));
       }
+      
+      if (!hasOption(SR_ALGORITHM))
+      {
+        SystemConfiguration.setProperty("pallier.secureRandom.algorithm", "NativePRNG");
+      }
+      else
+      {
+        SystemConfiguration.setProperty("pallier.secureRandom.algorithm", getOptionValue(SR_ALGORITHM));
+      }
+      
+      if (!hasOption(SR_PROVIDER))
+      {
+        SystemConfiguration.setProperty("pallier.secureRandom.provider", "SUN");
+      }
+      else
+      {
+        SystemConfiguration.setProperty("pallier.secureRandom.provider", getOptionValue(SR_PROVIDER));
+      }
     }
 
     // Parse decryption args
@@ -448,7 +469,21 @@ public class QuerierDriverCLI
     optionQUERIERFILE.setArgName(QUERIERFILE);
     optionQUERIERFILE.setType(String.class);
     options.addOption(optionQUERIERFILE);
-
+    
+    //SR_ALGORITHM
+    Option optionSR_ALGORITHM = new Option("srAlg", SR_ALGORITHM, true, "optional - specify the SecureRandom algorithm, defaults to NativePRNG");
+    optionSR_ALGORITHM.setRequired(false);
+    optionSR_ALGORITHM.setArgName(SR_ALGORITHM);
+    optionSR_ALGORITHM.setType(String.class);
+    options.addOption(optionSR_ALGORITHM);
+    
+    //SR_PROVIDERS
+    Option optionSR_PROVIDER = new Option("srProvider", SR_PROVIDER, true, "optional - specify the SecureRandom provider, defaults to SUN");
+    optionSR_PROVIDER.setRequired(false);
+    optionSR_PROVIDER.setArgName(SR_PROVIDER);
+    optionSR_PROVIDER.setType(String.class);
+    options.addOption(optionSR_PROVIDER);
+    
     return options;
   }
 


### PR DESCRIPTION
Added QuerierDriverCLI options to set the 'pallier.secureRandom.algorithm' and 'pallier.secureRandom.provider' options to be used in the SecureRandom constructor within the org.apache.pirk.encryption.Paillier class