### PR TITLE
[trivial] Enhancements to build XML and Paillier class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 	</repositories>
 
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<scala.version>2.10.4</scala.version>

--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
@@ -219,7 +219,7 @@ public class EncryptQuery
       {
         selectorQueryVecMappingCopy = new HashMap<Integer,Integer>(selectorQueryVecMapping);
       }
-      EncryptQueryRunnable runEnc = new EncryptQueryRunnable(dataPartitionBitSize, hashBitSize, paillier.copy(), selectorQueryVecMappingCopy, start, stop);
+      EncryptQueryRunnable runEnc = new EncryptQueryRunnable(dataPartitionBitSize, hashBitSize, paillier.clone(), selectorQueryVecMappingCopy, start, stop);
       runnables.add(runEnc);
       es.execute(runEnc);
     }


### PR DESCRIPTION
1) Updated the POM to consider Pirk's files as UTF-8 encoded, and avoid the warning during build.
2) Changed Paillier from the copy constructor to clone(), which is idiomatic to copying Java instances.
3) Modest reordering of while condition, to avoid lengthy mod() calls when later, simpler checks would fail.
4) Consistency in returning expression results from methods, rather than storing and returning a local.