### PR TITLE
[PIRK-12] Refactor EncryptQuery#encrypt(int)

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
@@ -20,11 +20,9 @@ package org.apache.pirk.querier.wideskies.encrypt;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -192,7 +190,7 @@ public class EncryptQuery
       {
         logger.info("Caught exception for selector = " + selector);
         e.printStackTrace();
-        // TODO: Check should continue?
+        // TODO: Check: should continue?
       }
 
       embedSelectorMap.put(sNum, embeddedSelector);
@@ -205,7 +203,7 @@ public class EncryptQuery
     // Encrypt and form the query vector
     ExecutorService es = Executors.newCachedThreadPool();
     ArrayList<EncryptQueryRunnable> runnables = new ArrayList<EncryptQueryRunnable>(numThreads);
-    int numElements = (int) Math.pow(2, queryInfo.getHashBitSize());
+    int numElements = 1 << queryInfo.getHashBitSize();  // 2^hashBitSize
 
     // Split the work across the requested number of threads
     int elementsPerThread = numElements / numThreads;

--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
@@ -125,7 +125,7 @@ public class EncryptQuery
     int hashBitSize = queryInfo.getHashBitSize();
 
     // Determine the query vector mappings for the selectors; vecPosition -> selectorNum
-    HashMap<Integer,Integer> selectorQueryVecMapping = computeSelectorQueryVecMapping();
+    HashMap<Integer,Integer> selectorQueryVecMapping = computeSelectorQueryVecMap();
  
     // Form the embedSelectorMap
     QuerySchema qSchema = LoadQuerySchemas.getSchema(queryInfo.getQueryType());
@@ -176,7 +176,7 @@ public class EncryptQuery
       {
         selectorQueryVecMappingCopy = new HashMap<Integer,Integer>(selectorQueryVecMapping);
       }
-      EncryptQueryRunnable runEnc = new EncryptQueryRunnable(dataPartitionBitSize, hashBitSize, paillier.copy(), selectorQueryVecMappingCopy, start, stop);
+      EncryptQueryRunnable runEnc = new EncryptQueryRunnable(dataPartitionBitSize, paillier.copy(), selectorQueryVecMappingCopy, start, stop);
       runnables.add(runEnc);
       es.execute(runEnc);
     }
@@ -219,7 +219,7 @@ public class EncryptQuery
     querier = new Querier(queryInfo, selectors, paillier, query, embedSelectorMap);
   }
 
-  private HashMap<Integer,Integer> computeSelectorQueryVecMapping()
+  private HashMap<Integer,Integer> computeSelectorQueryVecMap()
   {
     String hashKey = queryInfo.getHashKey();
     int keyCounter = 0;

--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
@@ -125,25 +125,7 @@ public class EncryptQuery
     HashMap<Integer,Integer> selectorQueryVecMapping = computeSelectorQueryVecMap();
 
     // Form the embedSelectorMap
-    QuerySchema qSchema = LoadQuerySchemas.getSchema(queryInfo.getQueryType());
-    DataSchema dSchema = LoadDataSchemas.getSchema(qSchema.getDataSchemaName());
-    String type = dSchema.getElementType(qSchema.getSelectorName());
-    int sNum = 0;
-    for (String selector : selectors)
-    {
-      String embeddedSelector = null;
-      try
-      {
-        embeddedSelector = QueryUtils.getEmbeddedSelector(selector, type, dSchema.getPartitionerForElement(qSchema.getSelectorName()));
-      } catch (Exception e)
-      {
-        logger.info("Caught exception for selector = " + selector);
-        e.printStackTrace();
-      }
-
-      embedSelectorMap.put(sNum, embeddedSelector);
-      ++sNum;
-    }
+    populateEmbeddedSelectorMap();
 
     parallelEncrypt(numThreads, selectorQueryVecMapping);
 
@@ -192,6 +174,30 @@ public class EncryptQuery
       }
     }
     return selectorQueryVecMapping;
+  }
+
+  private void populateEmbeddedSelectorMap()
+  {
+    QuerySchema qSchema = LoadQuerySchemas.getSchema(queryInfo.getQueryType());
+    DataSchema dSchema = LoadDataSchemas.getSchema(qSchema.getDataSchemaName());
+    String type = dSchema.getElementType(qSchema.getSelectorName());
+    int sNum = 0;
+    for (String selector : selectors)
+    {
+      String embeddedSelector = null;
+      try
+      {
+        embeddedSelector = QueryUtils.getEmbeddedSelector(selector, type, dSchema.getPartitionerForElement(qSchema.getSelectorName()));
+      } catch (Exception e)
+      {
+        logger.info("Caught exception for selector = " + selector);
+        e.printStackTrace();
+        // TODO: Check should continue?
+      }
+
+      embedSelectorMap.put(sNum, embeddedSelector);
+      ++sNum;
+    }
   }
 
   private void parallelEncrypt(int numThreads, HashMap<Integer,Integer> selectorQueryVecMapping) throws PIRException


### PR DESCRIPTION
Here are a few refactorings, as described in each commit message, primarily just pulling out logical steps into private helper methods.

Some points of note:
 - reduced the double while-loop/breaks structures to simpler single for-loops;
 - combined the includes key checks with the insertion to avoid double hashing in data structures;
 - simplify the runner.

NB: the original code would change a hash collision to hash0, hash01, hash012, ... but the new code goes to hash0, hash1, hash2, ...  This can be changed back if the original algorithm was intended, though it is unclear how growing the string helps.