### PR TITLE
[PIRK-16] Define XML schema definition files for Pirk's data and query schemas

### DIFF
--- a/src/main/java/org/apache/pirk/schema/data/LoadDataSchemas.java
+++ b/src/main/java/org/apache/pirk/schema/data/LoadDataSchemas.java
@@ -179,7 +179,15 @@ public class LoadDataSchemas
         // Pull out the attributes
         String name = eElement.getElementsByTagName("name").item(0).getTextContent().trim().toLowerCase();
         String type = eElement.getElementsByTagName("type").item(0).getTextContent().trim();
-        String isArray = eElement.getElementsByTagName("isArray").item(0).getTextContent().trim().toLowerCase();
+
+        // An absent isArray means false, and an empty isArray means true, otherwise take the value. 
+        String isArray = "false";
+        Node isArrayNode = eElement.getElementsByTagName("isArray").item(0);
+        if (isArrayNode != null)
+        {
+          String isArrayValue = isArrayNode.getTextContent().trim().toLowerCase();
+          isArray = isArrayValue.isEmpty() ? "true" : isArrayValue;
+        }
 
         // Pull and check the partitioner class -- if the partitioner tag doesn't exist, then
         // it defaults to the PrimitiveTypePartitioner

--- a/src/main/java/org/apache/pirk/test/utils/TestUtils.java
+++ b/src/main/java/org/apache/pirk/test/utils/TestUtils.java
@@ -111,9 +111,10 @@ public class TestUtils
     type.appendChild(doc.createTextNode(typeIn));
     element.appendChild(type);
 
-    Element isArray = doc.createElement("isArray");
-    isArray.appendChild(doc.createTextNode(isArrayIn));
-    element.appendChild(isArray);
+    if (isArrayIn.equals("true"))
+    {
+      element.appendChild(doc.createElement("isArray"));
+    }
 
     if (partitionerIn != null)
     {

--- a/src/main/resources/data-schema.xsd
+++ b/src/main/resources/data-schema.xsd
@@ -29,7 +29,7 @@
                             <xs:element name="name" type="xs:string" />
                             <xs:element name="type" type="xs:string" />
                             <xs:element name="isArray" type="xs:boolean"
-                                default="false" />
+                                default="true" minOccurs="0" />
                             <xs:element name="partitioner"
                                 type="xs:string" minOccurs="0" />
                         </xs:sequence>

--- a/src/main/resources/data-schema.xsd
+++ b/src/main/resources/data-schema.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ ~ Licensed to the Apache Software Foundation (ASF) under one or more
+ ~ contributor license agreements.  See the NOTICE file distributed with
+ ~ this work for additional information regarding copyright ownership.
+ ~ The ASF licenses this file to You under the Apache License, Version 2.0
+ ~ (the "License"); you may not use this file except in compliance with
+ ~ the License.  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ -->
+ <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://pirk.apache.org" xmlns="http://pirk.apache.org"
+    elementFormDefault="qualified">
+
+    <xs:element name="schema">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="schemaName" type="xs:string" />
+                <xs:element name="element" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="name" type="xs:string" />
+                            <xs:element name="type" type="xs:string" />
+                            <xs:element name="isArray" type="xs:boolean"
+                                default="false" />
+                            <xs:element name="partitioner"
+                                type="xs:string" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/src/main/resources/query-schema.xsd
+++ b/src/main/resources/query-schema.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ ~ Licensed to the Apache Software Foundation (ASF) under one or more
+ ~ contributor license agreements.  See the NOTICE file distributed with
+ ~ this work for additional information regarding copyright ownership.
+ ~ The ASF licenses this file to You under the Apache License, Version 2.0
+ ~ (the "License"); you may not use this file except in compliance with
+ ~ the License.  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://pirk.apache.org" xmlns="http://pirk.apache.org"
+    elementFormDefault="qualified">
+
+    <xs:element name="schema">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="schemaName" type="xs:string" />
+                <xs:element name="dataSchemaName" type="xs:string" />
+                <xs:element name="selectorName" type="xs:string" />
+                <xs:element name="elements">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="name" type="xs:string"
+                                maxOccurs="unbounded" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="filter" type="xs:string"
+                    minOccurs="0" />
+                <xs:element name="filterNames" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="name" type="xs:string" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
Reading the loader code, the "isArray" element is not optional.  Does it make sense and aid readability for me to tweak the loader to assume isArray is false by default? or do you want to keep it explicit?