### PR TITLE
Ensure stop list property is set for tests.

### DIFF
--- a/src/main/java/org/apache/pirk/test/utils/Inputs.java
+++ b/src/main/java/org/apache/pirk/test/utils/Inputs.java
@@ -42,6 +42,7 @@ import org.apache.pirk.schema.data.partitioner.PrimitiveTypePartitioner;
 import org.apache.pirk.schema.query.QuerySchemaLoader;
 import org.apache.pirk.test.distributed.DistributedTestDriver;
 import org.apache.pirk.utils.HDFS;
+import org.apache.pirk.utils.PIRException;
 import org.apache.pirk.utils.SystemConfiguration;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
@@ -390,27 +391,29 @@ public class Inputs
   /**
    * Creates PIR stoplist file
    */
-  public static String createPIRStopList(FileSystem fs, boolean hdfs) throws IOException
+  public static String createPIRStopList(FileSystem fs, boolean hdfs) throws IOException, PIRException
   {
     logger.info("PIR stopList file being created");
 
-    String tmpFileName;
-
-    ArrayList<String> elements = new ArrayList<>();
-    elements.add("something.else.on.stoplist");
-    elements.add("3.3.3.132");
+    List<String> elements = Arrays.asList("something.else.on.stoplist", "3.3.3.132");
 
     if (hdfs)
     {
       String pirStopListFile = SystemConfiguration.getProperty(DistributedTestDriver.PIR_STOPLIST_FILE);
-
+      if (pirStopListFile == null)
+      {
+        throw new PIRException("HDFS stop list file configuration name is required.");
+      }
       HDFS.writeFile(elements, fs, pirStopListFile, true);
-      logger.info("pirStopListFile file successfully created!");
+      logger.info("pirStopListFile file successfully created on hdfs!");
     }
 
-    tmpFileName = TestUtils.writeToTmpFile(elements, SystemConfiguration.getProperty(DistributedTestDriver.PIR_STOPLIST_FILE), null);
-
-    return tmpFileName;
+    String prefix = SystemConfiguration.getProperty("pir.stopListFile");
+    if (prefix == null)
+    {
+      throw new PIRException("Local stop list file configuration name is required.");
+    }
+    return TestUtils.writeToTmpFile(elements, prefix, null);
   }
 
   /**

--- a/src/main/java/org/apache/pirk/test/utils/TestUtils.java
+++ b/src/main/java/org/apache/pirk/test/utils/TestUtils.java
@@ -21,8 +21,8 @@ package org.apache.pirk.test.utils;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -293,25 +293,22 @@ public class TestUtils
    * Write the ArrayList<String to a tmp file in the local filesystem with the given fileName
    * 
    */
-  public static String writeToTmpFile(ArrayList<String> list, String fileName, String suffix) throws IOException
+  public static String writeToTmpFile(List<String> list, String fileName, String suffix) throws IOException
   {
-    String filename;
-
     File file = File.createTempFile(fileName, suffix);
     file.deleteOnExit();
-    filename = file.toString();
-    logger.info("localFS: file = " + file.toString());
+    logger.info("localFS: file = " + file);
 
-    FileOutputStream fos = new FileOutputStream(file);
-    BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos));
-
-    for (String s : list)
+    FileWriter fw = new FileWriter(file);
+    try (BufferedWriter bw = new BufferedWriter(fw))
     {
-      bw.write(s);
-      bw.newLine();
+      for (String s : list)
+      {
+        bw.write(s);
+        bw.newLine();
+      }
     }
-    bw.close();
 
-    return filename;
+    return file.getPath();
   }
 }

--- a/src/test/java/test/schema/query/LoadQuerySchemaTest.java
+++ b/src/test/java/test/schema/query/LoadQuerySchemaTest.java
@@ -43,6 +43,7 @@ import org.apache.pirk.schema.query.QuerySchemaRegistry;
 import org.apache.pirk.schema.query.filter.StopListFilter;
 import org.apache.pirk.test.utils.Inputs;
 import org.apache.pirk.test.utils.TestUtils;
+import org.apache.pirk.utils.PIRException;
 import org.apache.pirk.utils.SystemConfiguration;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -307,7 +308,7 @@ public class LoadQuerySchemaTest
   }
 
   // Create the stoplist file and alter the properties accordingly
-  private void createStopListFile() throws IOException
+  private void createStopListFile() throws IOException, PIRException
   {
     SystemConfiguration.setProperty("pir.stopListFile", "testStopListFile");
     String newSLFile = Inputs.createPIRStopList(null, false);


### PR DESCRIPTION
 - Now throws a PIR exception if the required property is not set.
 - Includes some tidy-up of temp file creation.