### PR TITLE
PIRK-29

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/Querier.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/Querier.java
@@ -66,7 +66,7 @@ public class Querier implements Serializable, Storable
     embedSelectorMap = embedSelectorMapInput;
   }
 
-  public QueryInfo getPirWatchlist()
+  public QueryInfo getQueryInfo()
   {
     return queryInfo;
   }

--- a/src/main/java/org/apache/pirk/querier/wideskies/Querier.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/Querier.java
@@ -17,7 +17,7 @@
  * under the License.
  *******************************************************************************/
 package org.apache.pirk.querier.wideskies;
-
+ 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Class to hold the information necessary for the PIR querier to perform decryption
+ *
  * 
  */
 public class Querier implements Serializable, Storable

--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
@@ -111,7 +111,7 @@ public class QuerierDriver implements Serializable
     if (action.equals("encrypt"))
     {
       queryType = qdriverCLI.getOptionValue(QuerierDriverCLI.TYPE);
-      queryID = qdriverCLI.getOptionValue(QuerierDriverCLI.QUERYNAME);
+      queryID = qdriverCLI.getOptionValue(QuerierDriverCLI.QUERYID);
       hashBitSize = Integer.parseInt(qdriverCLI.getOptionValue(QuerierDriverCLI.HASHBITSIZE));
       hashKey = qdriverCLI.getOptionValue(QuerierDriverCLI.HASHBITSIZE);
       dataPartitionBitSize = Integer.parseInt(qdriverCLI.getOptionValue(QuerierDriverCLI.DATAPARTITIONSIZE));
@@ -165,7 +165,7 @@ public class QuerierDriver implements Serializable
       logger.info("queryNum = " + queryNum + " numSelectors = " + numSelectors);
 
       // Set the necessary QueryInfo and Paillier objects
-      QueryInfo queryInfo = new QueryInfo(queryNum, numSelectors, hashBitSize, hashKey, dataPartitionBitSize, queryType, queryName, paillierBitSize,
+      QueryInfo queryInfo = new QueryInfo(queryNum, numSelectors, hashBitSize, hashKey, dataPartitionBitSize, queryType, queryID, paillierBitSize,
           useMemLookupTable, embedSelector, useHDFSLookupTable);
 
       if (SystemConfiguration.getProperty("pir.embedQuerySchema").equals("true"))
@@ -203,7 +203,14 @@ public class QuerierDriver implements Serializable
       Response response = storage.recall(inputFile, Response.class);
       Querier querier = storage.recall(querierFile, Querier.class);
 
-      querier.  
+      /** if the user-specified QueryID in the Querier does not match the QueryID returned
+          in the Response object, throw an error */
+      if(!querier.getQueryInfo().getQueryID().equals(response.getQueryInfo().getQueryID()))
+      {
+        logger.error("The QueryID in the Response does not match the QueryID specified in the Querier.");
+      
+        System.exit(0); // exit
+      }
       
       // Perform decryption and output the result file
       DecryptResponse decryptResponse = new DecryptResponse(response, querier);

--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
@@ -91,7 +91,7 @@ public class QuerierDriver implements Serializable
     int dataPartitionBitSize = 0;
     int paillierBitSize = 0;
     int certainty = 0;
-    String queryName = null;
+    String queryID = null;
     int bitSet = -1;
     boolean embedSelector = true;
     boolean useMemLookupTable = false;
@@ -111,7 +111,7 @@ public class QuerierDriver implements Serializable
     if (action.equals("encrypt"))
     {
       queryType = qdriverCLI.getOptionValue(QuerierDriverCLI.TYPE);
-      queryName = qdriverCLI.getOptionValue(QuerierDriverCLI.QUERYNAME);
+      queryID = qdriverCLI.getOptionValue(QuerierDriverCLI.QUERYNAME);
       hashBitSize = Integer.parseInt(qdriverCLI.getOptionValue(QuerierDriverCLI.HASHBITSIZE));
       hashKey = qdriverCLI.getOptionValue(QuerierDriverCLI.HASHBITSIZE);
       dataPartitionBitSize = Integer.parseInt(qdriverCLI.getOptionValue(QuerierDriverCLI.DATAPARTITIONSIZE));

--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
@@ -203,6 +203,8 @@ public class QuerierDriver implements Serializable
       Response response = storage.recall(inputFile, Response.class);
       Querier querier = storage.recall(querierFile, Querier.class);
 
+      querier.  
+      
       // Perform decryption and output the result file
       DecryptResponse decryptResponse = new DecryptResponse(response, querier);
       decryptResponse.decrypt(numThreads);

--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
@@ -30,6 +30,9 @@ import org.apache.pirk.utils.SystemConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
+import java.text.SimpleDateFormat;
+
 /**
  * Class for parsing the command line options for the QuerierDriver
  */
@@ -244,7 +247,14 @@ public class QuerierDriverCLI
         logger.info("Must have the option " + QUERYID);
         return false;
       }
-      SystemConfiguration.setProperty(QUERYID, getOptionValue(QUERYID));
+      
+      // create a formatted date/time string
+      Date date = new Date();
+      SimpleDateFormat sdf = new SimpleDateFormat("MM.dd.yyyy_hh.mm.ss");
+      String formattedDate = sdf.format(date);
+      
+      // append date/time string to queryID for uniqueness
+      SystemConfiguration.setProperty(QUERYID, getOptionValue(QUERYID) + "_" + formattedDate);
 
       if (!hasOption(BITSET))
       {
@@ -504,7 +514,7 @@ public class QuerierDriverCLI
 
     return options;
   }
-
+  
   /**
    * Prints out the help message
    */

--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriverCLI.java
@@ -55,7 +55,7 @@ public class QuerierDriverCLI
   public static final String PAILLIERBITSIZE = "paillierBitSize";
   public static final String BITSET = "bitSet";
   public static final String CERTAINTY = "certainty";
-  public static final String QUERYNAME = "queryName";
+  public static final String QUERYID = "queryID";
   public static final String QUERYSCHEMAS = "querySchemas";
   public static final String DATASCHEMAS = "dataSchemas";
   public static final String EMBEDSELECTOR = "embedSelector";
@@ -239,12 +239,12 @@ public class QuerierDriverCLI
       }
       SystemConfiguration.setProperty(CERTAINTY, getOptionValue(CERTAINTY));
 
-      if (!hasOption(QUERYNAME))
+      if (!hasOption(QUERYID))
       {
-        logger.info("Must have the option " + QUERYNAME);
+        logger.info("Must have the option " + QUERYID);
         return false;
       }
-      SystemConfiguration.setProperty(QUERYNAME, getOptionValue(QUERYNAME));
+      SystemConfiguration.setProperty(QUERYID, getOptionValue(QUERYID));
 
       if (!hasOption(BITSET))
       {
@@ -397,9 +397,9 @@ public class QuerierDriverCLI
     options.addOption(optionTYPE);
 
     // NAME
-    Option optionNAME = new Option("qn", QUERYNAME, true, "required for encryption -- Name of the query");
+    Option optionNAME = new Option("qn", QUERYID, true, "required for encryption -- Name of the query");
     optionNAME.setRequired(false);
-    optionNAME.setArgName(QUERYNAME);
+    optionNAME.setArgName(QUERYID);
     optionNAME.setType(String.class);
     options.addOption(optionNAME);
 

--- a/src/main/java/org/apache/pirk/query/wideskies/QueryInfo.java
+++ b/src/main/java/org/apache/pirk/query/wideskies/QueryInfo.java
@@ -43,7 +43,7 @@ public class QueryInfo implements Serializable
 
   private String queryType = null; // QueryType string const
 
-  private String queryName = null; // Name of query
+  private String queryID = null; // Unique query ID
 
   private int paillierBitSize = 0; // Paillier modulus size
 
@@ -67,12 +67,12 @@ public class QueryInfo implements Serializable
   QuerySchema qSchema = null;
 
   public QueryInfo(double queryNumInput, int numSelectorsInput, int hashBitSizeInput, String hashKeyInput, int dataPartitionBitSizeInput,
-      String queryTypeInput, String queryNameInput, int paillierBitSizeIn, boolean useExpLookupTableInput, boolean embedSelectorInput,
+      String queryTypeInput, String queryIDInput, int paillierBitSizeIn, boolean useExpLookupTableInput, boolean embedSelectorInput,
       boolean useHDFSExpLookupTableInput)
   {
     queryNum = queryNumInput;
     queryType = queryTypeInput;
-    queryName = queryNameInput;
+    queryID = queryIDInput;
 
     numSelectors = numSelectorsInput;
 
@@ -98,9 +98,9 @@ public class QueryInfo implements Serializable
   }
 
   public QueryInfo(double queryNumInput, int numSelectorsInput, int hashBitSizeInput, String hashKeyInput, int dataPartitionBitSizeInput,
-      String queryTypeInput, String queryNameInput, int paillierBitSizeIn)
+      String queryTypeInput, String queryIDInput, int paillierBitSizeIn)
   {
-    this(queryNumInput, numSelectorsInput, hashBitSizeInput, hashKeyInput, dataPartitionBitSizeInput, queryTypeInput, queryNameInput, paillierBitSizeIn, false,
+    this(queryNumInput, numSelectorsInput, hashBitSizeInput, hashKeyInput, dataPartitionBitSizeInput, queryTypeInput, queryIDInput, paillierBitSizeIn, false,
         true, false);
   }
 
@@ -114,9 +114,9 @@ public class QueryInfo implements Serializable
     return queryType;
   }
 
-  public String getQueryName()
+  public String getQueryID()
   {
-    return queryName;
+    return queryID;
   }
 
   public int getNumSelectors()
@@ -183,13 +183,13 @@ public class QueryInfo implements Serializable
   {
     logger.info("queryNum = " + queryNum + " numSelectors = " + numSelectors + " hashBitSize = " + hashBitSize + " hashKey = " + hashKey
         + " dataPartitionBitSize = " + dataPartitionBitSize + " numBitsPerDataElement = " + numBitsPerDataElement + " numPartitionsPerDataElement = "
-        + numPartitionsPerDataElement + " queryType = " + queryType + " queryName = " + queryName + " paillierBitSize = " + paillierBitSize
+        + numPartitionsPerDataElement + " queryType = " + queryType + " queryID = " + queryID + " paillierBitSize = " + paillierBitSize
         + " useExpLookupTable = " + useExpLookupTable + " useHDFSExpLookupTable = " + useHDFSExpLookupTable + " embedSelector = " + embedSelector);
   }
 
   public QueryInfo copy()
   {
-    return new QueryInfo(this.queryNum, this.numSelectors, this.hashBitSize, this.hashKey, this.dataPartitionBitSize, this.queryType, this.queryName,
+    return new QueryInfo(this.queryNum, this.numSelectors, this.hashBitSize, this.hashKey, this.dataPartitionBitSize, this.queryType, this.queryID,
         this.paillierBitSize, this.useExpLookupTable, this.embedSelector, this.useHDFSExpLookupTable);
   }
 }

--- a/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeExpLookupTable.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeExpLookupTable.java
@@ -67,7 +67,7 @@ public class ComputeExpLookupTable
   {
     JavaPairRDD<Integer,Iterable<Tuple2<Integer,BigInteger>>> expCalculations;
 
-    logger.info("Creating expTable in hdfs for queryName = " + query.getQueryInfo().getQueryName());
+    logger.info("Creating expTable in hdfs for queryName = " + query.getQueryInfo().getQueryID());
 
     // Prep the output directory
     Path outPathExp = new Path(outputDirExp);

--- a/src/main/java/org/apache/pirk/schema/response/QueryResponseJSON.java
+++ b/src/main/java/org/apache/pirk/schema/response/QueryResponseJSON.java
@@ -204,7 +204,7 @@ public class QueryResponseJSON implements Serializable
   {
     jsonObj.put(EVENT_TYPE, queryInfo.getQueryType());
     jsonObj.put(QUERY_ID, queryInfo.getQueryNum());
-    jsonObj.put(QUERY_NAME, queryInfo.getQueryName());
+    jsonObj.put(QUERY_NAME, queryInfo.getQueryID());
   }
 
   @Override


### PR DESCRIPTION
Implemented a check to ensure the queryID (formerly named queryName) in the Querier matches the queryID in the Response object.

Added a timestamp to the queryID for uniqueness.

Renamed some fields/methods for uniformity.
