### PR TITLE
Change DataPartitioner to refer to List interface.

### DIFF
--- a/src/main/java/org/apache/pirk/benchmark/PaillierBenchmark.java
+++ b/src/main/java/org/apache/pirk/benchmark/PaillierBenchmark.java
@@ -59,7 +59,7 @@ public class PaillierBenchmark
     @Setup(org.openjdk.jmh.annotations.Level.Trial)
     public void setUp()
     {
-      int systemPrimeCertainty = Integer.parseInt(SystemConfiguration.getProperty("pir.primeCertainty", "100"));
+      int systemPrimeCertainty = SystemConfiguration.getIntProperty("pir.primeCertainty", 100);
       try
       {
         pallier = new Paillier(MODULUS_SIZE, systemPrimeCertainty);

--- a/src/main/java/org/apache/pirk/encryption/ModPowAbstraction.java
+++ b/src/main/java/org/apache/pirk/encryption/ModPowAbstraction.java
@@ -29,9 +29,9 @@ import com.squareup.jnagmp.Gmp;
  */
 public final class ModPowAbstraction
 {
-  private static boolean useGMPForModPow = SystemConfiguration.getProperty("paillier.useGMPForModPow").equals("true");
+  private static boolean useGMPForModPow = SystemConfiguration.isSetTrue("paillier.useGMPForModPow");
 
-  private static boolean useGMPConstantTimeMethods = SystemConfiguration.getProperty("paillier.GMPConstantTimeMode").equals("true");
+  private static boolean useGMPConstantTimeMethods = SystemConfiguration.isSetTrue("paillier.GMPConstantTimeMode");
 
   /**
    * Performs modPow: ({@code base}^{@code exponent}) mod {@code modulus}
@@ -85,7 +85,7 @@ public final class ModPowAbstraction
 
   public static void reloadConfiguration()
   {
-    useGMPForModPow = SystemConfiguration.getProperty("paillier.useGMPForModPow").equals("true");
-    useGMPConstantTimeMethods = SystemConfiguration.getProperty("paillier.GMPConstantTimeMode").equals("true");
+    useGMPForModPow = SystemConfiguration.isSetTrue("paillier.useGMPForModPow");
+    useGMPConstantTimeMethods = SystemConfiguration.isSetTrue("paillier.GMPConstantTimeMode");
   }
 }

--- a/src/main/java/org/apache/pirk/encryption/Paillier.java
+++ b/src/main/java/org/apache/pirk/encryption/Paillier.java
@@ -116,7 +116,7 @@ public class Paillier implements Cloneable, Serializable
     bitLength = bitLengthInput;
 
     // Verify the prime conditions are satisfied
-    int primeCertainty = Integer.parseInt(SystemConfiguration.getProperty("pir.primeCertainty", "128"));
+    int primeCertainty = SystemConfiguration.getIntProperty("pir.primeCertainty", 128);
     BigInteger three = BigInteger.valueOf(3);
     if ((pInput.compareTo(three) < 0) || (qInput.compareTo(three) < 0) || pInput.equals(qInput) || !pInput.isProbablePrime(primeCertainty)
         || !qInput.isProbablePrime(primeCertainty))
@@ -161,7 +161,7 @@ public class Paillier implements Cloneable, Serializable
   {
     bitLength = bitLengthInput;
 
-    int systemPrimeCertainty = Integer.parseInt(SystemConfiguration.getProperty("pir.primeCertainty", "128"));
+    int systemPrimeCertainty = SystemConfiguration.getIntProperty("pir.primeCertainty", 128);
     if (certainty < systemPrimeCertainty)
     {
       throw new PIRException("Input certainty = " + certainty + " is less than allowed system lower bound = " + systemPrimeCertainty);

--- a/src/main/java/org/apache/pirk/encryption/PrimeGenerator.java
+++ b/src/main/java/org/apache/pirk/encryption/PrimeGenerator.java
@@ -58,7 +58,7 @@ public class PrimeGenerator
   private static final HashMap<Integer,BigInteger> lowerBoundCache = new HashMap<>();
   private static final HashMap<Integer,BigInteger> minimumDifferenceCache = new HashMap<>();
 
-  private static boolean additionalChecksEnabled = SystemConfiguration.getProperty("pallier.FIPSPrimeGenerationChecks").equals("true");
+  private static boolean additionalChecksEnabled = SystemConfiguration.isSetTrue("pallier.FIPSPrimeGenerationChecks");
 
   /**
    * Method to generate a single prime

--- a/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/QuerierDriver.java
@@ -118,9 +118,9 @@ public class QuerierDriver implements Serializable
       dataPartitionBitSize = Integer.parseInt(SystemConfiguration.getProperty(QuerierProps.DATAPARTITIONSIZE));
       paillierBitSize = Integer.parseInt(SystemConfiguration.getProperty(QuerierProps.PAILLIERBITSIZE));
       certainty = Integer.parseInt(SystemConfiguration.getProperty(QuerierProps.CERTAINTY));
-      embedSelector = SystemConfiguration.getProperty(QuerierProps.EMBEDSELECTOR, "true").equals("true");
-      useMemLookupTable = SystemConfiguration.getProperty(QuerierProps.USEMEMLOOKUPTABLE, "false").equals("true");
-      useHDFSLookupTable = SystemConfiguration.getProperty(QuerierProps.USEHDFSLOOKUPTABLE, "false").equals("true");
+      embedSelector = SystemConfiguration.getBooleanProperty(QuerierProps.EMBEDSELECTOR, true);
+      useMemLookupTable = SystemConfiguration.getBooleanProperty(QuerierProps.USEMEMLOOKUPTABLE, false);
+      useHDFSLookupTable = SystemConfiguration.getBooleanProperty(QuerierProps.USEHDFSLOOKUPTABLE, false);
 
       if (SystemConfiguration.hasProperty(QuerierProps.BITSET))
       {
@@ -169,7 +169,7 @@ public class QuerierDriver implements Serializable
       QueryInfo queryInfo = new QueryInfo(queryNum, numSelectors, hashBitSize, hashKey, dataPartitionBitSize, queryType, queryName, paillierBitSize,
           useMemLookupTable, embedSelector, useHDFSLookupTable);
 
-      if (SystemConfiguration.getProperty("pir.embedQuerySchema").equals("true"))
+      if (SystemConfiguration.isSetTrue("pir.embedQuerySchema"))
       {
         queryInfo.addQuerySchema(QuerySchemaRegistry.get(queryType));
       }

--- a/src/main/java/org/apache/pirk/querier/wideskies/decrypt/DecryptResponseRunnable.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/decrypt/DecryptResponseRunnable.java
@@ -61,7 +61,7 @@ public class DecryptResponseRunnable implements Runnable
     queryInfo = queryInfoInput;
     embedSelectorMap = embedSelectorMapInput;
 
-    if (SystemConfiguration.getProperty("pir.allowAdHocQuerySchemas", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pir.allowAdHocQuerySchemas", false))
     {
       if ((qSchema = queryInfo.getQuerySchema()) == null)
       {

--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
@@ -115,7 +115,7 @@ public class EncryptQuery
    */
   public void encrypt() throws InterruptedException, PIRException
   {
-    int numThreads = Integer.parseInt(SystemConfiguration.getProperty("numThreads", "1"));
+    int numThreads = SystemConfiguration.getIntProperty("numThreads", 1);
     encrypt(numThreads);
   }
 

--- a/src/main/java/org/apache/pirk/query/wideskies/QueryUtils.java
+++ b/src/main/java/org/apache/pirk/query/wideskies/QueryUtils.java
@@ -232,9 +232,9 @@ public class QueryUtils
   /**
    * Method to convert the given selector into the extracted BigInteger partitions
    */
-  public static ArrayList<BigInteger> embeddedSelectorToPartitions(Object selector, String type, Object partitioner) throws Exception
+  public static List<BigInteger> embeddedSelectorToPartitions(Object selector, String type, Object partitioner) throws Exception
   {
-    ArrayList<BigInteger> parts;
+    List<BigInteger> parts;
 
     int partitionBits = ((DataPartitioner) partitioner).getBits(type);
     if (partitionBits > 32) // hash and add 32-bit hash value to partitions

--- a/src/main/java/org/apache/pirk/query/wideskies/QueryUtils.java
+++ b/src/main/java/org/apache/pirk/query/wideskies/QueryUtils.java
@@ -57,7 +57,7 @@ public class QueryUtils
 
     DataSchema dSchema = DataSchemaRegistry.get(qSchema.getDataSchemaName());
 
-    int numArrayElementsToReturn = Integer.parseInt(SystemConfiguration.getProperty("pir.numReturnArrayElements", "1"));
+    int numArrayElementsToReturn = SystemConfiguration.getIntProperty("pir.numReturnArrayElements", 1);
 
     logger.debug("parts.size() = " + parts.size());
 

--- a/src/main/java/org/apache/pirk/responder/wideskies/mapreduce/ComputeResponseTool.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/mapreduce/ComputeResponseTool.java
@@ -131,7 +131,7 @@ public class ComputeResponseTool extends Configured implements Tool
 
     query = new HadoopFileSystemStore(fs).recall(queryInputDir, Query.class);
     queryInfo = query.getQueryInfo();
-    if (SystemConfiguration.getProperty("pir.allowAdHocQuerySchemas", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pir.allowAdHocQuerySchemas", false))
     {
       qSchema = queryInfo.getQuerySchema();
     }
@@ -225,9 +225,9 @@ public class ComputeResponseTool extends Configured implements Tool
     queryInputDir = SystemConfiguration.getProperty("pir.queryInput");
     stopListFile = SystemConfiguration.getProperty("pir.stopListFile");
 
-    useHDFSLookupTable = SystemConfiguration.getProperty("pir.useHDFSLookupTable").equals("true");
+    useHDFSLookupTable = SystemConfiguration.isSetTrue("pir.useHDFSLookupTable");
 
-    numReduceTasks = Integer.parseInt(SystemConfiguration.getProperty("pir.numReduceTasks", "1"));
+    numReduceTasks = SystemConfiguration.getIntProperty("pir.numReduceTasks", 1);
   }
 
   private boolean computeExpTable() throws IOException, ClassNotFoundException, InterruptedException
@@ -246,7 +246,7 @@ public class ComputeResponseTool extends Configured implements Tool
     TreeMap<Integer,BigInteger> queryElements = query.getQueryElements();
     ArrayList<Integer> keys = new ArrayList<>(queryElements.keySet());
 
-    int numSplits = Integer.parseInt(SystemConfiguration.getProperty("pir.expCreationSplits", "100"));
+    int numSplits = SystemConfiguration.getIntProperty("pir.expCreationSplits", 100);
     int elementsPerSplit = (int) Math.floor(queryElements.size() / numSplits);
     logger.info("numSplits = " + numSplits + " elementsPerSplit = " + elementsPerSplit);
     for (int i = 0; i < numSplits; ++i)
@@ -289,7 +289,7 @@ public class ComputeResponseTool extends Configured implements Tool
     jobExp.setMapOutputValueClass(Text.class);
 
     // Set the reducer and output params
-    int numExpLookupPartitions = Integer.parseInt(SystemConfiguration.getProperty("pir.numExpLookupPartitions", "100"));
+    int numExpLookupPartitions = SystemConfiguration.getIntProperty("pir.numExpLookupPartitions", 100);
     jobExp.setNumReduceTasks(numExpLookupPartitions);
     jobExp.setReducerClass(ExpTableReducer.class);
 

--- a/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeExpLookupTable.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeExpLookupTable.java
@@ -86,12 +86,12 @@ public class ComputeExpLookupTable
     TreeMap<Integer,BigInteger> queryElements = query.getQueryElements();
     ArrayList<Integer> keys = new ArrayList<>(queryElements.keySet());
 
-    int numSplits = Integer.parseInt(SystemConfiguration.getProperty("pir.expCreationSplits", "100"));
+    int numSplits = SystemConfiguration.getIntProperty("pir.expCreationSplits", 100);
     JavaRDD<Integer> queryHashes = sc.parallelize(keys, numSplits);
 
     // Generate the exp table
     // <queryHash, <<power>,<element^power mod N^2>>
-    int numExpLookupPartitions = Integer.parseInt(SystemConfiguration.getProperty("pir.numExpLookupPartitions", "100"));
+    int numExpLookupPartitions = SystemConfiguration.getIntProperty("pir.numExpLookupPartitions", 100);
     expCalculations = queryHashes.flatMapToPair(new ExpTableGenerator(bVars)).groupByKey(numExpLookupPartitions);
 
     if (!useModExpJoin)

--- a/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeResponse.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeResponse.java
@@ -135,7 +135,7 @@ public class ComputeResponse
 
     queryInput = SystemConfiguration.getProperty("pir.queryInput");
     String stopListFile = SystemConfiguration.getProperty("pir.stopListFile");
-    useModExpJoin = SystemConfiguration.getProperty("pir.useModExpJoin", "false").equals("true");
+    useModExpJoin = SystemConfiguration.getBooleanProperty("pir.useModExpJoin", false);
 
     logger.info("outputFile = " + outputFile + " queryInputDir = " + queryInput + " stopListFile = " + stopListFile + " esQuery = " + esQuery
         + " esResource = " + esResource);
@@ -175,7 +175,7 @@ public class ComputeResponse
     bVars.setQueryInfo(queryInfo);
 
     QuerySchema qSchema = null;
-    if (SystemConfiguration.getProperty("pir.allowAdHocQuerySchemas", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pir.allowAdHocQuerySchemas", false))
     {
       qSchema = queryInfo.getQuerySchema();
     }
@@ -191,19 +191,18 @@ public class ComputeResponse
     // Set the local cache flag
     bVars.setUseLocalCache(SystemConfiguration.getProperty("pir.useLocalCache", "true"));
 
-    useHDFSLookupTable = SystemConfiguration.getProperty("pir.useHDFSLookupTable").equals("true");
+    useHDFSLookupTable = SystemConfiguration.isSetTrue("pir.useHDFSLookupTable");
 
     // Set the hit limit variables
     bVars.setLimitHitsPerSelector(Boolean.valueOf(SystemConfiguration.getProperty("pir.limitHitsPerSelector")));
     bVars.setMaxHitsPerSelector(Integer.parseInt(SystemConfiguration.getProperty("pir.maxHitsPerSelector")));
 
     // Set the number of data and column multiplication partitions
-    String numDataPartsString = SystemConfiguration.getProperty("pir.numDataPartitions", "1000");
-    numDataPartitions = Integer.parseInt(numDataPartsString);
-    numColMultPartitions = Integer.parseInt(SystemConfiguration.getProperty("pir.numColMultPartitions", numDataPartsString));
+    numDataPartitions = SystemConfiguration.getIntProperty("pir.numDataPartitions", 1000);
+    numColMultPartitions = SystemConfiguration.getIntProperty("pir.numColMultPartitions", numDataPartitions);
 
     // Whether or not we are performing a reduceByKey or a groupByKey->reduce for column multiplication
-    colMultReduceByKey = SystemConfiguration.getProperty("pir.colMultReduceByKey", "false").equals("true");
+    colMultReduceByKey = SystemConfiguration.getBooleanProperty("pir.colMultReduceByKey", false);
 
     // Set the expDir
     bVars.setExpDir(outputDirExp);

--- a/src/main/java/org/apache/pirk/responder/wideskies/standalone/Responder.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/standalone/Responder.java
@@ -73,7 +73,7 @@ public class Responder
     queryInfo = query.getQueryInfo();
     queryType = queryInfo.getQueryType();
 
-    if (SystemConfiguration.getProperty("pir.allowAdHocQuerySchemas", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pir.allowAdHocQuerySchemas", false))
     {
       qSchema = queryInfo.getQuerySchema();
     }

--- a/src/main/java/org/apache/pirk/schema/data/partitioner/DataPartitioner.java
+++ b/src/main/java/org/apache/pirk/schema/data/partitioner/DataPartitioner.java
@@ -20,7 +20,6 @@ package org.apache.pirk.schema.data.partitioner;
 
 import java.io.Serializable;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.pirk.utils.PIRException;
@@ -33,36 +32,36 @@ import org.apache.pirk.utils.PIRException;
 public interface DataPartitioner extends Serializable
 {
   /**
-   * Method to partition the given Object into an ArrayList of BigInteger partition elements given its type identifier
+   * Method to partition the given Object into a List of BigInteger partition elements given its type identifier.
    * <p>
-   * If the Object does not have/need a specific type identifier, use null
+   * If the Object does not have/need a specific type identifier, use null.
    */
-  ArrayList<BigInteger> toPartitions(Object object, String type) throws PIRException;
+  List<BigInteger> toPartitions(Object object, String type) throws PIRException;
 
   /**
-   * Method to reconstruct an Object given an ArrayList of its BigInteger partition elements and its type identifier
+   * Method to reconstruct an Object given a List of its BigInteger partition elements and its type identifier.
    * <p>
-   * If the Object does not have/need a specific type identifier, use null
+   * If the Object does not have/need a specific type identifier, use null.
    */
-  Object fromPartitions(ArrayList<BigInteger> parts, int partsIndex, String type) throws PIRException;
+  Object fromPartitions(List<BigInteger> parts, int partsIndex, String type) throws PIRException;
 
   /**
-   * Method to return the number of bits of an object with the given type
+   * Returns the number of bits of an object with the given type.
    */
   int getBits(String type) throws PIRException;
 
   /**
-   * Create partitions for an array of the same type of elements - used when a data value field is an array and we wish to encode these into the return value
+   * Creates partitions for an array of the same type of elements - used when a data value field is an array and we wish to encode these into the return value.
    */
-  ArrayList<BigInteger> arrayToPartitions(List<?> elementList, String type) throws PIRException;
+  List<BigInteger> arrayToPartitions(List<?> elementList, String type) throws PIRException;
 
   /**
-   * Method to get an empty set of partitions by data type - used for padding return array values
+   * Method to get an empty set of partitions by data type - used for padding return array values.
    */
-  ArrayList<BigInteger> getPaddedPartitions(String type) throws PIRException;
+  List<BigInteger> getPaddedPartitions(String type) throws PIRException;
 
   /**
-   * Method to get the number of partitions of the data object given the type
+   * Method to get the number of partitions of the data object given the type.
    */
   int getNumPartitions(String type) throws PIRException;
 }

--- a/src/main/java/org/apache/pirk/schema/data/partitioner/IPDataPartitioner.java
+++ b/src/main/java/org/apache/pirk/schema/data/partitioner/IPDataPartitioner.java
@@ -48,7 +48,7 @@ public class IPDataPartitioner implements DataPartitioner
   }
 
   @Override
-  public Object fromPartitions(ArrayList<BigInteger> parts, int partsIndex, String type)
+  public Object fromPartitions(List<BigInteger> parts, int partsIndex, String type)
   {
     Object element;
 

--- a/src/main/java/org/apache/pirk/schema/data/partitioner/IPDataPartitioner.java
+++ b/src/main/java/org/apache/pirk/schema/data/partitioner/IPDataPartitioner.java
@@ -84,7 +84,7 @@ public class IPDataPartitioner implements DataPartitioner
   {
     ArrayList<BigInteger> parts = new ArrayList<>();
 
-    int numArrayElementsToReturn = Integer.parseInt(SystemConfiguration.getProperty("pir.numReturnArrayElements", "1"));
+    int numArrayElementsToReturn = SystemConfiguration.getIntProperty("pir.numReturnArrayElements", 1);
     for (int i = 0; i < numArrayElementsToReturn; ++i)
     {
       if (elementList.size() > i) // we may have an element with a list rep that has fewer than numArrayElementsToReturn elements

--- a/src/main/java/org/apache/pirk/schema/data/partitioner/ISO8601DatePartitioner.java
+++ b/src/main/java/org/apache/pirk/schema/data/partitioner/ISO8601DatePartitioner.java
@@ -58,7 +58,7 @@ public class ISO8601DatePartitioner implements DataPartitioner
   }
 
   @Override
-  public Object fromPartitions(ArrayList<BigInteger> parts, int partsIndex, String type) throws PIRException
+  public Object fromPartitions(List<BigInteger> parts, int partsIndex, String type) throws PIRException
   {
     long dateLongFormat = (long) ptp.fromPartitions(parts, partsIndex, PrimitiveTypePartitioner.LONG);
 

--- a/src/main/java/org/apache/pirk/schema/data/partitioner/PrimitiveTypePartitioner.java
+++ b/src/main/java/org/apache/pirk/schema/data/partitioner/PrimitiveTypePartitioner.java
@@ -438,7 +438,7 @@ public class PrimitiveTypePartitioner implements DataPartitioner
   {
     ArrayList<BigInteger> parts = new ArrayList<>();
 
-    int numArrayElementsToReturn = Integer.parseInt(SystemConfiguration.getProperty("pir.numReturnArrayElements", "1"));
+    int numArrayElementsToReturn = SystemConfiguration.getIntProperty("pir.numReturnArrayElements", 1);
     for (int i = 0; i < numArrayElementsToReturn; ++i)
     {
       if (elementList.size() > i) // we may have an element with a list rep that has fewer than numArrayElementsToReturn elements

--- a/src/main/java/org/apache/pirk/schema/data/partitioner/PrimitiveTypePartitioner.java
+++ b/src/main/java/org/apache/pirk/schema/data/partitioner/PrimitiveTypePartitioner.java
@@ -101,7 +101,7 @@ public class PrimitiveTypePartitioner implements DataPartitioner
    */
   public static BigInteger formBitMask(int partitionSize)
   {
-    return (BigInteger.valueOf(2).pow(partitionSize)).subtract(BigInteger.ONE);
+    return BigInteger.valueOf(2).pow(partitionSize).subtract(BigInteger.ONE);
   }
 
   /**
@@ -111,39 +111,7 @@ public class PrimitiveTypePartitioner implements DataPartitioner
   @Override
   public int getNumPartitions(String type) throws PIRException
   {
-    int partitionSize = 8;
-
-    int numParts;
-    switch (type)
-    {
-      case BYTE:
-        numParts = Byte.SIZE / partitionSize;
-        break;
-      case SHORT:
-        numParts = Short.SIZE / partitionSize;
-        break;
-      case INT:
-        numParts = Integer.SIZE / partitionSize;
-        break;
-      case LONG:
-        numParts = Long.SIZE / partitionSize;
-        break;
-      case FLOAT:
-        numParts = Float.SIZE / partitionSize;
-        break;
-      case DOUBLE:
-        numParts = Double.SIZE / partitionSize;
-        break;
-      case CHAR:
-        numParts = Character.SIZE / partitionSize;
-        break;
-      case STRING:
-        numParts = Integer.parseInt(SystemConfiguration.getProperty("pir.stringBits")) / partitionSize;
-        break;
-      default:
-        throw new PIRException("type = " + type + " not recognized!");
-    }
-    return numParts;
+    return getBits(type) / 8;
   }
 
   /**
@@ -189,7 +157,7 @@ public class PrimitiveTypePartitioner implements DataPartitioner
    * Reconstructs the object from the partitions
    */
   @Override
-  public Object fromPartitions(ArrayList<BigInteger> parts, int partsIndex, String type) throws PIRException
+  public Object fromPartitions(List<BigInteger> parts, int partsIndex, String type) throws PIRException
   {
     Object element;
 
@@ -239,7 +207,6 @@ public class PrimitiveTypePartitioner implements DataPartitioner
       {
         byte[] bytes = appendBytes(parts, partsIndex, getNumPartitions(type));
         element = new String(bytes).trim(); // this should remove 0 padding added for partitioning underflowing strings
-
         break;
       }
       default:
@@ -248,7 +215,7 @@ public class PrimitiveTypePartitioner implements DataPartitioner
     return element;
   }
 
-  private byte[] appendBytes(ArrayList<BigInteger> parts, int partsIndex, int numParts)
+  private byte[] appendBytes(List<BigInteger> parts, int partsIndex, int numParts)
   {
     ByteArrayBuffer buf = new ByteArrayBuffer(numParts);
     for (int i = 0; i < numParts; ++i)
@@ -354,7 +321,7 @@ public class PrimitiveTypePartitioner implements DataPartitioner
           case CHAR:
             if (obj instanceof String)
             {
-              bytes = ByteBuffer.allocate(numParts).putChar(((String) (obj)).charAt(0)).array();
+              bytes = ByteBuffer.allocate(numParts).putChar(((String) obj).charAt(0)).array();
             }
             else
             {
@@ -367,7 +334,7 @@ public class PrimitiveTypePartitioner implements DataPartitioner
         for (byte b : bytes)
         {
           // Make sure that BigInteger treats the byte as 'unsigned' literal
-          parts.add(BigInteger.valueOf(((long) b) & 0xFF));
+          parts.add(BigInteger.valueOf((long) b & 0xFF));
         }
         break;
     }

--- a/src/main/java/org/apache/pirk/test/distributed/testsuite/DistTestSuite.java
+++ b/src/main/java/org/apache/pirk/test/distributed/testsuite/DistTestSuite.java
@@ -347,19 +347,19 @@ public class DistTestSuite
     logger.info("fileFinalResults = " + fileFinalResults.getAbsolutePath());
 
     boolean embedSelector = false;
-    if (SystemConfiguration.getProperty("pirTest.embedSelector", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pirTest.embedSelector", false))
     {
       embedSelector = true;
     }
 
     boolean useExpLookupTable = false;
-    if (SystemConfiguration.getProperty("pirTest.useExpLookupTable", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pirTest.useExpLookupTable", false))
     {
       useExpLookupTable = true;
     }
 
     boolean useHDFSExpLookupTable = false;
-    if (SystemConfiguration.getProperty("pirTest.useHDFSExpLookupTable", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pirTest.useHDFSExpLookupTable", false))
     {
       useHDFSExpLookupTable = true;
     }

--- a/src/main/java/org/apache/pirk/test/utils/BaseTests.java
+++ b/src/main/java/org/apache/pirk/test/utils/BaseTests.java
@@ -94,7 +94,7 @@ public class BaseTests
     logger.info("results:");
     printResultList(results);
 
-    if (isDistributed && SystemConfiguration.getProperty("pir.limitHitsPerSelector").equals("true"))
+    if (isDistributed && SystemConfiguration.isSetTrue("pir.limitHitsPerSelector"))
     {
       // 3 elements returned - one for each qname -- a.b.c.com, d.e.com, something.else
       if (results.size() != 3)
@@ -494,7 +494,7 @@ public class BaseTests
       values = StringUtils.jsonArrayStringToArrayList((String) dataMap.get(fieldName));
     }
 
-    int numArrayElementsToReturn = Integer.parseInt(SystemConfiguration.getProperty("pir.numReturnArrayElements", "1"));
+    int numArrayElementsToReturn = SystemConfiguration.getIntProperty("pir.numReturnArrayElements", 1);
     for (int i = 0; i < numArrayElementsToReturn; ++i)
     {
       if (i < values.size())
@@ -521,7 +521,7 @@ public class BaseTests
 
     ArrayList<Short> values = (ArrayList<Short>) dataMap.get(fieldName);
 
-    int numArrayElementsToReturn = Integer.parseInt(SystemConfiguration.getProperty("pir.numReturnArrayElements", "1"));
+    int numArrayElementsToReturn = SystemConfiguration.getIntProperty("pir.numReturnArrayElements", 1);
     for (int i = 0; i < numArrayElementsToReturn; ++i)
     {
       if (i < values.size())

--- a/src/main/java/org/apache/pirk/test/utils/StandaloneQuery.java
+++ b/src/main/java/org/apache/pirk/test/utils/StandaloneQuery.java
@@ -77,15 +77,15 @@ public class StandaloneQuery
     logger.info("fileQuerier = " + fileQuerier.getAbsolutePath() + " fileQuery  = " + fileQuery.getAbsolutePath() + " responseFile = "
         + fileResponse.getAbsolutePath() + " fileFinalResults = " + fileFinalResults.getAbsolutePath());
 
-    boolean embedSelector = SystemConfiguration.getProperty("pirTest.embedSelector", "false").equals("true");
-    boolean useExpLookupTable = SystemConfiguration.getProperty("pirTest.useExpLookupTable", "false").equals("true");
-    boolean useHDFSExpLookupTable = SystemConfiguration.getProperty("pirTest.useHDFSExpLookupTable", "false").equals("true");
+    boolean embedSelector = SystemConfiguration.getBooleanProperty("pirTest.embedSelector", false);
+    boolean useExpLookupTable = SystemConfiguration.getBooleanProperty("pirTest.useExpLookupTable", false);
+    boolean useHDFSExpLookupTable = SystemConfiguration.getBooleanProperty("pirTest.useHDFSExpLookupTable", false);
 
     // Set the necessary objects
     QueryInfo queryInfo = new QueryInfo(BaseTests.queryNum, selectors.size(), BaseTests.hashBitSize, BaseTests.hashKey, BaseTests.dataPartitionBitSize,
         queryType, queryType + "_" + BaseTests.queryNum, BaseTests.paillierBitSize, useExpLookupTable, embedSelector, useHDFSExpLookupTable);
 
-    if (SystemConfiguration.getProperty("pir.embedQuerySchema", "false").equals("true"))
+    if (SystemConfiguration.getBooleanProperty("pir.embedQuerySchema", false))
     {
       queryInfo.addQuerySchema(qSchema);
     }

--- a/src/main/java/org/apache/pirk/utils/SystemConfiguration.java
+++ b/src/main/java/org/apache/pirk/utils/SystemConfiguration.java
@@ -42,7 +42,7 @@ public class SystemConfiguration
 {
   private static final Logger logger = LoggerFactory.getLogger(SystemConfiguration.class);
 
-  private static final Properties props;
+  private static final Properties props = new Properties();
 
   /**
    * By default, these files should be found on the root of the classpath
@@ -55,34 +55,30 @@ public class SystemConfiguration
 
   static
   {
-    props = new Properties();
     initialize();
   }
 
   public static void initialize()
   {
+    props.clear();
+
     // First try to load the default properties file
-    loadPropsFromStream(DEFAULT_PROPERTY_FILE);
+    loadPropsFromResource(DEFAULT_PROPERTY_FILE);
 
     // Try to load props from the querier and responder property files, if they exist
-    loadPropsFromStream(QUERIER_PROPERTIES_FILE);
-    loadPropsFromStream(RESPONDER_PROPERTIES_FILE);
+    loadPropsFromResource(QUERIER_PROPERTIES_FILE);
+    loadPropsFromResource(RESPONDER_PROPERTIES_FILE);
 
     // Try to load the local properties files, if they exists
     loadPropsFromDir(getProperty(LOCAL_PROPERTIES_DIR));
   }
 
   /**
-   * Clear the properties
-   */
-  public static void clearProperties()
-  {
-    props.clear();
-  }
-
-  /**
-   * Gets the specified property; returns null if the property isn't found.
+   * Gets the specified property; returns <code>null</code> if the property isn't found.
    * 
+   * @param propertyName
+   *          The name of the requested property.
+   * @return The value of the property, or <code>null</code> if the property cannot be found.
    */
   public static String getProperty(String propertyName)
   {
@@ -90,8 +86,13 @@ public class SystemConfiguration
   }
 
   /**
-   * Gets the specified property; returns the defaultValue if the property isn't found.
+   * Gets the specified property as a <code>String</code>, or the default value if the property isn't found.
    * 
+   * @param propertyName
+   *          The name of the requested string property value.
+   * @param defaultvalue
+   *          The value to return if the property is undefined.
+   * @return The value of the requested property, or the default value if the property is undefined.
    */
   public static String getProperty(String propertyName, String defaultValue)
   {
@@ -99,51 +100,110 @@ public class SystemConfiguration
   }
 
   /**
-   * Set a property
+   * Gets the specified property as an <code>int</code>, or the default value if the property isn't found.
+   * 
+   * @param propertyName
+   *          The name of the requested int property value.
+   * @param defaultValue
+   *          The value to return if the property is undefined.
+   * @return The value of the requested property, or the default value if the property is undefined.
+   * @throws NumberFormatException
+   *           If the property does not contain a parsable <code>int</code> value.
+   */
+  public static int getIntProperty(String propertyName, int defaultValue)
+  {
+    String value = props.getProperty(propertyName);
+    return (value == null) ? defaultValue : Integer.parseInt(value);
+  }
+
+  /**
+   * Gets the specified property as a <code>boolean</code>, or the default value if the property isn't defined.
+   * 
+   * @param propertyName
+   *          The name of the requested boolean property value.
+   * @param defaultValue
+   *          The value to return if the property is undefined.
+   * @return <code>true</code> if the property is defined and has the value "true", otherwise <code>defaultValue</code>.
+   */
+  public static boolean getBooleanProperty(String propertyName, boolean defaultValue)
+  {
+    return (isSetTrue(propertyName)) ? true : defaultValue;
+  }
+
+  /**
+   * Returns <code>true</code> iff the specified boolean property value is "true".
+   * <p>
+   * If the property is not found, or it's value is not "true" then the method will return <code>false</code>.
+   * 
+   * @param propertyName
+   *          The name of the requested boolean property value.
+   * @return <code>true</code> if the property is defined and has the value "true", otherwise <code>false</code>.
+   */
+  public static boolean isSetTrue(String propertyName)
+  {
+    String value = props.getProperty(propertyName);
+    return "true".equals(value);
+  }
+
+  /**
+   * Sets the property to the given value.
+   * <p>
+   * Any previous values stored at the same property name are replaced.
+   * 
+   * @param propertyName
+   *          The name of the property to set.
+   * @param value
+   *          The property value.
    */
   public static void setProperty(String propertyName, String value)
   {
     props.setProperty(propertyName, value);
   }
 
+  /**
+   * Returns true iff the given property name is defined.
+   * 
+   * @param propertyName
+   *          The property name to test.
+   * @return <code>true</code> if the property is found in the configuration, or <code>false</code> otherwise.
+   */
   public static boolean hasProperty(String propertyName)
   {
     return props.containsKey(propertyName);
   }
 
   /**
-   * Append a property via a comma separated list
+   * Appends a property via a comma separated list
    * <p>
-   * If the property does not exist, it adds it
+   * If the property does not exist, it adds it.
+   * 
+   * @param propertyName
+   *          The property whose value is to be appended with the given value.
+   * @param value
+   *          The value to be stored, or appended to the current value.
    */
-  public static void appendProperty(String property, String propToAdd)
+  public static void appendProperty(String propertyName, String value)
   {
-    String value = props.getProperty(property);
+    String oldValue = props.getProperty(propertyName);
 
-    if (value != null && !value.equals("none"))
+    if (oldValue != null && !oldValue.equals("none"))
     {
-      value += "," + propToAdd;
+      oldValue += "," + value;
     }
     else
     {
-      value = propToAdd;
+      oldValue = value;
     }
-    props.setProperty(property, value);
+    props.setProperty(propertyName, oldValue);
   }
 
   /**
-   * Reset all properties to the default values
-   */
-  public static void resetProperties()
-  {
-    clearProperties();
-    initialize();
-  }
-
-  /**
-   * Loads the properties from local properties file in the specified directory
+   * Loads the properties from local properties file in the specified directory.
    * <p>
-   * Only files ending in '.properties' will be loaded
+   * All files ending in '.properties' will be loaded. The new properties are added to the current system configuration.
+   * 
+   * @param dirName
+   *          The directory to search for the new properties files.
    */
   public static void loadPropsFromDir(String dirName)
   {
@@ -166,7 +226,12 @@ public class SystemConfiguration
   }
 
   /**
-   * Loads the properties from the specified file
+   * Loads the properties from the specified file.
+   * <p>
+   * The new properties are added to the current system configuration.
+   * 
+   * @param file
+   *          The properties file containing the system properties to add.
    */
   public static void loadPropsFromFile(File file)
   {
@@ -176,7 +241,6 @@ public class SystemConfiguration
       {
         logger.info("Loading properties file '" + file.getAbsolutePath() + "'");
         props.load(stream);
-        stream.close();
       } catch (IOException e)
       {
         logger.error("Problem loading properties file '" + file.getAbsolutePath() + "'");
@@ -190,9 +254,14 @@ public class SystemConfiguration
   }
 
   /**
-   * Loads the properties from the specified file on the classpath
+   * Loads the properties from the specified resource on the current classloader.
+   * <p>
+   * The new properties are added to the current system configuration.
+   * 
+   * @param name
+   *          The name of the resource defining the properties.
    */
-  public static void loadPropsFromStream(String name)
+  public static void loadPropsFromResource(String name)
   {
     try (InputStream stream = SystemConfiguration.class.getClassLoader().getResourceAsStream(name))
     {
@@ -200,7 +269,6 @@ public class SystemConfiguration
       {
         logger.info("Loading file '" + name + "'");
         props.load(stream);
-        stream.close();
       }
       else
       {

--- a/src/test/java/org/apache/pirk/general/PaillierTest.java
+++ b/src/test/java/org/apache/pirk/general/PaillierTest.java
@@ -126,7 +126,7 @@ public class PaillierTest
 
     try
     {
-      int systemPrimeCertainty = Integer.parseInt(SystemConfiguration.getProperty("pir.primeCertainty", "128"));
+      int systemPrimeCertainty = SystemConfiguration.getIntProperty("pir.primeCertainty", 128);
       Paillier paillier = new Paillier(3072, systemPrimeCertainty - 10);
       fail("Paillier constructor did not throw PIRException for certainty less than system default of " + systemPrimeCertainty);
     } catch (PIRException ignore)
@@ -226,7 +226,7 @@ public class PaillierTest
     testPaillerWithKeyGenerationGeneral();
 
     // Reset the properties
-    SystemConfiguration.resetProperties();
+    SystemConfiguration.initialize();
 
     logger.info("Ending testPaillierWithKeyGeneration: ");
   }


### PR DESCRIPTION
 - Update the DataPartitioner interface to refer to List interface in
preference to ArrayList concrete type, giving implementers additional
options.