### PR TITLE
Convert DecryptResponseRunnable to a Callable.

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/decrypt/DecryptResponse.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/decrypt/DecryptResponse.java
@@ -29,9 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.pirk.encryption.Paillier;
 import org.apache.pirk.querier.wideskies.Querier;
@@ -48,6 +51,8 @@ import org.slf4j.LoggerFactory;
 public class DecryptResponse
 {
   private static final Logger logger = LoggerFactory.getLogger(DecryptResponse.class);
+  
+  private static final BigInteger TWO_BI = BigInteger.valueOf(2);
 
   private final Response response;
 
@@ -87,25 +92,24 @@ public class DecryptResponse
 
     Paillier paillier = querier.getPaillier();
     List<String> selectors = querier.getSelectors();
-    HashMap<Integer,String> embedSelectorMap = querier.getEmbedSelectorMap();
+    Map<Integer,String> embedSelectorMap = querier.getEmbedSelectorMap();
 
     // Perform decryption on the encrypted columns
-    ArrayList<BigInteger> rElements = decryptElements(response.getResponseElements(), paillier);
+    List<BigInteger> rElements = decryptElements(response.getResponseElements(), paillier);
     logger.debug("rElements.size() = " + rElements.size());
 
     // Pull the necessary parameters
     int dataPartitionBitSize = queryInfo.getDataPartitionBitSize();
 
     // Initialize the result map and masks-- removes initialization checks from code below
-    HashMap<String,BigInteger> selectorMaskMap = new HashMap<>();
+    Map<String,BigInteger> selectorMaskMap = new HashMap<>();
     int selectorNum = 0;
-    BigInteger twoBI = BigInteger.valueOf(2);
     for (String selector : selectors)
     {
       resultMap.put(selector, new ArrayList<>());
 
       // 2^{selectorNum*dataPartitionBitSize}(2^{dataPartitionBitSize} - 1)
-      BigInteger mask = twoBI.pow(selectorNum * dataPartitionBitSize).multiply((twoBI.pow(dataPartitionBitSize).subtract(BigInteger.ONE)));
+      BigInteger mask = TWO_BI.pow(selectorNum * dataPartitionBitSize).multiply((TWO_BI.pow(dataPartitionBitSize).subtract(BigInteger.ONE)));
       logger.debug("selector = " + selector + " mask = " + mask.toString(2));
       selectorMaskMap.put(selector, mask);
 
@@ -120,7 +124,7 @@ public class DecryptResponse
     }
     int elementsPerThread = selectors.size() / numThreads; // Integral division.
 
-    ArrayList<DecryptResponseRunnable> runnables = new ArrayList<>();
+    List<Future<Map<String,List<QueryResponseJSON>>>> futures = new ArrayList<>();
     for (int i = 0; i < numThreads; ++i)
     {
       // Grab the range of the thread and create the corresponding partition of selectors
@@ -137,33 +141,30 @@ public class DecryptResponse
       }
 
       // Create the runnable and execute
-      // selectorMaskMap and rElements are synchronized, pirWatchlist is copied, selectors is partitioned
-      DecryptResponseRunnable runDec = new DecryptResponseRunnable(rElements, selectorsPartition, selectorMaskMap, queryInfo.clone(), embedSelectorMap);
-      runnables.add(runDec);
-      es.execute(runDec);
-    }
-
-    // Allow threads to complete
-    es.shutdown(); // previously submitted tasks are executed, but no new tasks will be accepted
-    boolean finished = es.awaitTermination(1, TimeUnit.DAYS); // waits until all tasks complete or until the specified timeout
-
-    if (!finished)
-    {
-      throw new PIRException("Decryption threads did not finish in the alloted time");
+      DecryptResponseRunnable<Map<String,List<QueryResponseJSON>>> runDec = new DecryptResponseRunnable<>(rElements, selectorsPartition, selectorMaskMap, queryInfo.clone(), embedSelectorMap);
+      futures.add(es.submit(runDec));
     }
 
     // Pull all decrypted elements and add to resultMap
-    for (DecryptResponseRunnable runner : runnables)
+    try
     {
-      resultMap.putAll(runner.getResultMap());
+      for (Future<Map<String,List<QueryResponseJSON>>> future : futures)
+      {
+        resultMap.putAll(future.get(1, TimeUnit.DAYS));
+      }
+    } catch (TimeoutException | ExecutionException e)
+    {
+      throw new PIRException("Exception in decryption threads.", e);
     }
+    
+    es.shutdown();
   }
 
   // Method to perform basic decryption of each raw response element - does not
   // extract and reconstruct the data elements
-  private ArrayList<BigInteger> decryptElements(TreeMap<Integer,BigInteger> elements, Paillier paillier)
+  private List<BigInteger> decryptElements(TreeMap<Integer,BigInteger> elements, Paillier paillier)
   {
-    ArrayList<BigInteger> decryptedElements = new ArrayList<>();
+    List<BigInteger> decryptedElements = new ArrayList<>();
 
     for (BigInteger encElement : elements.values())
     {


### PR DESCRIPTION
  - Allows task to return a value and throw checked exceptions.
  - Further tidy-up in decrypt response.

Passing results between threads via an unsynchronized variable is prone to error, so converted to use Callable and Futures which allows returning the results directly.