### PR TITLE
PIRK-54: Log Levels not Functioning

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -40,9 +40,9 @@
 		<Logger name="org.apache.hadoop.hbase" level="info" additivity="false"/>
 		<Logger name="org.apache.hadoop.hbase.zookeeper" level="warn" additivity="false"/>
 		<Logger name="org.apache.zookeeper" level="error" additivity="false"/>
-		<Root level="info">
-			<AppenderRef ref="STDOUT"/>
-			<AppenderRef ref="RollingFile"/>
+		<Root level="debug">
+			<AppenderRef ref="STDOUT" level="debug"/>
+			<AppenderRef ref="RollingFile" level="debug"/>
 		</Root>
 	</Loggers>
 


### PR DESCRIPTION
Not tested this PR thoroughly, in the Log file I do see both Info and Debug showing up, seems like we may need to add a filter at appender level to filter out the info messages. 

If someone else could test this on Console output, and are still seeing both info and debug; we could consider adding a filter and that should only display the debug statements.