### PR TITLE
[Bug fix] Reset loop index correctly on hash collision.

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
@@ -189,7 +189,7 @@ public class EncryptQuery
         selectorQueryVecMapping.clear();
         hashKey = queryInfo.getHashKey() + ++keyCounter;
         logger.debug("index = " + index + "selector = " + selector + " hash collision = " + hash + " new key = " + hashKey);
-        index = 0;
+        index = -1;
       }
     }
     return selectorQueryVecMapping;


### PR DESCRIPTION
Where there is a hash collision detected, the entire calculation is attempted with a new ```hashKey```.  The loop var ```index``` will be incremented on the next iteration, so needs to be reset to -1 to pick up selector(0).