### PR TITLE
Removed the <distributionManagement> and <repositories> entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	</parent>
 
 	<groupId>org.apache.pirk</groupId>
-	<artifactId>apache-pirk</artifactId>
+	<artifactId>pirk</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
@@ -71,37 +71,6 @@
 		<system>JIRA</system>
 		<url>https://issues.apache.org/jira/browse/PIRK</url>
 	</issueManagement>
-
-	<repositories>
-		<repository>
-			<id>mvn-public</id>
-			<url>http://mvnrepository.com/artifact</url>
-			<snapshots>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>repository.apache.org</id>
-			<name>Apache Repository</name>
-			<url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-
-	<distributionManagement>
-		<repository>
-			<id>repository.apache.org</id>
-			<name>Apache Repository</name>
-			<layout>default</layout>
-			<url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
-			<uniqueVersion>false</uniqueVersion>
-		</repository>
-	</distributionManagement>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Please see the updated settings.xml (1) that needs to be local to all Release Managers to enable deployment of artifacts to staging 

1. https://gist.github.com/smarthi/ac1b5058f05ab17d2f84862940ec4eba