### PR TITLE
Pass query elements into Query constructor.

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQueryTask.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQueryTask.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Runnable class for multithreaded PIR encryption
  */
-class EncryptQueryTask implements Callable<SortedMap<Integer,BigInteger>>
+final class EncryptQueryTask implements Callable<SortedMap<Integer,BigInteger>>
 {
   private static final Logger logger = LoggerFactory.getLogger(EncryptQueryTask.class);
 

--- a/src/main/java/org/apache/pirk/query/wideskies/Query.java
+++ b/src/main/java/org/apache/pirk/query/wideskies/Query.java
@@ -23,7 +23,6 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
@@ -42,9 +41,9 @@ public class Query implements Serializable, Storable
 
   private static final Logger logger = LoggerFactory.getLogger(Query.class);
 
-  private final QueryInfo qInfo; // holds all query info
+  private final QueryInfo queryInfo; // holds all query info
 
-  private final TreeMap<Integer,BigInteger> queryElements = new TreeMap<>(); // query elements - ordered on insertion
+  private final SortedMap<Integer,BigInteger> queryElements; // query elements - ordered on insertion
 
   // lookup table for exponentiation of query vectors - based on dataPartitionBitSize
   // element -> <power, element^power mod N^2>
@@ -57,19 +56,20 @@ public class Query implements Serializable, Storable
   private final BigInteger N; // N=pq, RSA modulus for the Paillier encryption associated with the queryElements
   private final BigInteger NSquared;
 
-  public Query(QueryInfo queryInfoIn, BigInteger NInput)
+  public Query(QueryInfo queryInfo, BigInteger N, SortedMap<Integer,BigInteger> queryElements)
   {
-    qInfo = queryInfoIn;
-    N = NInput;
+    this.queryInfo = queryInfo;
+    this.N = N;
     NSquared = N.pow(2);
+    this.queryElements = queryElements;
   }
 
   public QueryInfo getQueryInfo()
   {
-    return qInfo;
+    return queryInfo;
   }
 
-  public TreeMap<Integer,BigInteger> getQueryElements()
+  public SortedMap<Integer,BigInteger> getQueryElements()
   {
     return queryElements;
   }
@@ -104,33 +104,13 @@ public class Query implements Serializable, Storable
     expFileBasedLookup = expInput;
   }
 
-  public Map<BigInteger,Map<Integer,BigInteger>> getExpTable()
-  {
-    return expTable;
-  }
-
-  public void setExpTable(Map<BigInteger,Map<Integer,BigInteger>> expTableInput)
-  {
-    expTable = expTableInput;
-  }
-
-  public void addQueryElements(SortedMap<Integer,BigInteger> elements)
-  {
-    queryElements.putAll(elements);
-  }
-
-  public boolean containsElement(BigInteger element)
-  {
-    return queryElements.containsValue(element);
-  }
-
   /**
    * This should be called after all query elements have been added in order to generate the expTable. For int exponentiation with BigIntegers, assumes that
    * dataPartitionBitSize < 32.
    */
   public void generateExpTable()
   {
-    int maxValue = (1 << qInfo.getDataPartitionBitSize()) - 1; // 2^partitionBitSize - 1
+    int maxValue = (1 << queryInfo.getDataPartitionBitSize()) - 1; // 2^partitionBitSize - 1
 
     queryElements.values().parallelStream().forEach(new Consumer<BigInteger>()
     {
@@ -151,6 +131,7 @@ public class Query implements Serializable, Storable
 
   public BigInteger getExp(BigInteger value, int power)
   {
-    return expTable.get(value).get(power);
+    Map<Integer,BigInteger> powerMap = expTable.get(value);
+    return (powerMap == null) ? null : powerMap.get(power);
   }
 }

--- a/src/main/java/org/apache/pirk/query/wideskies/QueryInfo.java
+++ b/src/main/java/org/apache/pirk/query/wideskies/QueryInfo.java
@@ -166,12 +166,12 @@ public class QueryInfo implements Serializable, Cloneable
     return dataPartitionBitSize;
   }
 
-  public boolean getUseExpLookupTable()
+  public boolean useExpLookupTable()
   {
     return useExpLookupTable;
   }
 
-  public boolean getUseHDFSExpLookupTable()
+  public boolean useHDFSExpLookupTable()
   {
     return useHDFSExpLookupTable;
   }

--- a/src/main/java/org/apache/pirk/responder/wideskies/mapreduce/ComputeResponseTool.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/mapreduce/ComputeResponseTool.java
@@ -24,7 +24,8 @@ import java.io.InputStreamReader;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.TreeMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -154,7 +155,7 @@ public class ComputeResponseTool extends Configured implements Tool
     Path outPathFinal = new Path(outputDirFinal);
 
     // If we are using distributed exp tables -- Create the expTable file in hdfs for this query, if it doesn't exist
-    if ((queryInfo.getUseHDFSExpLookupTable() || useHDFSLookupTable) && query.getExpFileBasedLookup().isEmpty())
+    if ((queryInfo.useHDFSExpLookupTable() || useHDFSLookupTable) && query.getExpFileBasedLookup().isEmpty())
     {
       success = computeExpTable();
     }
@@ -243,8 +244,8 @@ public class ComputeResponseTool extends Configured implements Tool
       fs.delete(splitDir, true);
     }
     // Write the query hashes to the split files
-    TreeMap<Integer,BigInteger> queryElements = query.getQueryElements();
-    ArrayList<Integer> keys = new ArrayList<>(queryElements.keySet());
+    Map<Integer,BigInteger> queryElements = query.getQueryElements();
+    List<Integer> keys = new ArrayList<>(queryElements.keySet());
 
     int numSplits = SystemConfiguration.getIntProperty("pir.expCreationSplits", 100);
     int elementsPerSplit = queryElements.size() / numSplits; // Integral division.

--- a/src/main/java/org/apache/pirk/responder/wideskies/mapreduce/RowCalcReducer.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/mapreduce/RowCalcReducer.java
@@ -115,7 +115,7 @@ public class RowCalcReducer extends Reducer<IntWritable,BytesArrayWritable,LongW
     logger.debug("Processing reducer for hash = " + rowIndex);
     ctx.getCounter(MRStats.NUM_HASHES_REDUCER).increment(1);
 
-    if (queryInfo.getUseHDFSExpLookupTable())
+    if (queryInfo.useHDFSExpLookupTable())
     {
       ComputeEncryptedRow.loadCacheFromHDFS(fs, query.getExpFile(rowIndex.get()), query);
     }

--- a/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeExpLookupTable.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeExpLookupTable.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -83,8 +83,8 @@ public class ComputeExpLookupTable
     }
 
     // Write the query hashes to a RDD
-    TreeMap<Integer,BigInteger> queryElements = query.getQueryElements();
-    ArrayList<Integer> keys = new ArrayList<>(queryElements.keySet());
+    Map<Integer,BigInteger> queryElements = query.getQueryElements();
+    List<Integer> keys = new ArrayList<>(queryElements.keySet());
 
     int numSplits = SystemConfiguration.getIntProperty("pir.expCreationSplits", 100);
     JavaRDD<Integer> queryHashes = sc.parallelize(keys, numSplits);

--- a/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeResponse.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/spark/ComputeResponse.java
@@ -335,7 +335,7 @@ public class ComputeResponse
     logger.info("Performing query: ");
 
     // If we are using distributed exp tables -- Create the expTable file in hdfs for this query, if it doesn't exist
-    if ((queryInfo.getUseHDFSExpLookupTable() || useHDFSLookupTable) && query.getExpFileBasedLookup().isEmpty())
+    if ((queryInfo.useHDFSExpLookupTable() || useHDFSLookupTable) && query.getExpFileBasedLookup().isEmpty())
     {
       // <queryHash, <<power>,<element^power mod N^2>>
       JavaPairRDD<Integer,Iterable<Tuple2<Integer,BigInteger>>> expCalculations = ComputeExpLookupTable.computeExpTable(sc, fs, bVars, query, queryInput,

--- a/src/main/java/org/apache/pirk/responder/wideskies/spark/EncRowCalc.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/spark/EncRowCalc.java
@@ -78,7 +78,7 @@ public class EncRowCalc implements PairFlatMapFunction<Tuple2<Integer,Iterable<L
     int rowIndex = hashDocTuple._1;
     accum.incNumHashes(1);
 
-    if (queryInfo.getUseHDFSExpLookupTable())
+    if (queryInfo.useHDFSExpLookupTable())
     {
       FileSystem fs;
       try

--- a/src/main/java/org/apache/pirk/responder/wideskies/standalone/Responder.java
+++ b/src/main/java/org/apache/pirk/responder/wideskies/standalone/Responder.java
@@ -190,7 +190,7 @@ public class Responder
       logger.debug("Before: columns.get(" + (i + rowCounter) + ") = " + columns.get(i + rowCounter));
 
       BigInteger exp;
-      if (query.getQueryInfo().getUseExpLookupTable() && !query.getQueryInfo().getUseHDFSExpLookupTable()) // using the standalone
+      if (query.getQueryInfo().useExpLookupTable() && !query.getQueryInfo().useHDFSExpLookupTable()) // using the standalone
       // lookup table
       {
         exp = query.getExp(rowQuery, hitValPartitions.get(i).intValue());

--- a/src/main/java/org/apache/pirk/utils/KeyedHash.java
+++ b/src/main/java/org/apache/pirk/utils/KeyedHash.java
@@ -74,7 +74,6 @@ public class KeyedHash
 
     } catch (NoSuchAlgorithmException e)
     {
-
       logger.info(e.toString());
       bitLimitedHash = hash(key, bitSize, input);
     }


### PR DESCRIPTION
 - Compute encrypted query elements, and pass in as part of query
construction rather than adding them afterwards to an existing query.
 - Other minor tidy-up, using interfaces, renaming boolean returning
methods for exp tables.