### PR TITLE
[minor] Fix license and term in math_deck

### DIFF
--- a/contrib/math_deck/math_deck.tex
+++ b/contrib/math_deck/math_deck.tex
@@ -1,3 +1,21 @@
+%
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+%
 \documentclass{beamer}
 \usepackage[T1]{fontenc}
 \usepackage{amsmath}
@@ -283,7 +301,7 @@ full Paillier scheme that sacrifices no security over the general case.
   \begin{algorithmic}[1]
     \Procedure{Paillier encryption}{}
     \State \Given \(N\) and a message \(m\in\zmodn\)
-    \State \Select a random value \(\zeta\in\zmodntunits\)
+    \State \Select a random value \(\zeta\in \left(\zmodn\right)^{\times}\)
     \State \Return \(\mathcal{E}(m) = (1+mN)\zeta^{N}\bmod{N^{2}}\)
     \EndProcedure
   \end{algorithmic}


### PR DESCRIPTION
 - Added ALv2 comment header to keep RAT happy.
 - Fixed zeta constraint in Paillier as used by Wideskies encryption
algorithm.