### PR TITLE
[WIP] Create Paillier bridge to hide test constructor

### DIFF
--- a/src/main/java/org/apache/pirk/encryption/Paillier.java
+++ b/src/main/java/org/apache/pirk/encryption/Paillier.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Ref: Paillier, Pascal. "Public-Key Cryptosystems Based on Composite Degree Residuosity Classes." EUROCRYPT'99.
  */
-public class Paillier implements Cloneable, Serializable
+public final class Paillier implements Cloneable, Serializable
 {
   private static final long serialVersionUID = 1L;
 
@@ -105,13 +105,11 @@ public class Paillier implements Cloneable, Serializable
 
   private int bitLength = 0; // bit length of the modulus N
 
-  /**
-   * Constructor with all parameters p,q, and bitLengthInput specified
+  /* Constructor with all parameters p,q, and bitLengthInput specified
    * <p>
-   * Only used, at this point, for testing purposes
-   *
+   * Only used, at this point, for testing purposes.
    */
-  public Paillier(BigInteger pInput, BigInteger qInput, int bitLengthInput) throws PIRException
+  Paillier(BigInteger pInput, BigInteger qInput, int bitLengthInput) throws PIRException
   {
     bitLength = bitLengthInput;
 

--- a/src/test/java/org/apache/pirk/encryption/PaillierBridge.java
+++ b/src/test/java/org/apache/pirk/encryption/PaillierBridge.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pirk.encryption;
+
+import java.math.BigInteger;
+
+import org.apache.pirk.utils.PIRException;
+
+public class PaillierBridge
+{
+  public static Paillier newPaillier(BigInteger p, BigInteger q, int bitLength) throws PIRException
+  {
+    return new Paillier(p, q, bitLength);
+  }
+}

--- a/src/test/java/org/apache/pirk/general/PaillierTest.java
+++ b/src/test/java/org/apache/pirk/general/PaillierTest.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import java.util.Random;
 
 import org.apache.pirk.encryption.Paillier;
+import org.apache.pirk.encryption.PaillierBridge;
 import org.apache.pirk.utils.PIRException;
 import org.apache.pirk.utils.SystemConfiguration;
 import org.junit.BeforeClass;
@@ -84,7 +85,7 @@ public class PaillierTest
   {
     try
     {
-      Paillier paillier = new Paillier(BigInteger.valueOf(2), BigInteger.valueOf(2), 128);
+      Paillier paillier = PaillierBridge.newPaillier(BigInteger.valueOf(2), BigInteger.valueOf(2), 128);
       assertNotNull(paillier);
       fail("Paillier constructor did not throw PIRException for p,q < 3");
     } catch (PIRException ignore)
@@ -92,7 +93,7 @@ public class PaillierTest
 
     try
     {
-      Paillier paillier = new Paillier(BigInteger.valueOf(2), BigInteger.valueOf(3), 128);
+      Paillier paillier = PaillierBridge.newPaillier(BigInteger.valueOf(2), BigInteger.valueOf(3), 128);
       assertNotNull(paillier);
       fail("Paillier constructor did not throw PIRException for p < 3");
     } catch (PIRException ignore)
@@ -100,7 +101,7 @@ public class PaillierTest
 
     try
     {
-      Paillier paillier = new Paillier(BigInteger.valueOf(3), BigInteger.valueOf(2), 128);
+      Paillier paillier = PaillierBridge.newPaillier(BigInteger.valueOf(3), BigInteger.valueOf(2), 128);
       assertNotNull(paillier);
       fail("Paillier constructor did not throw PIRException for q < 3");
     } catch (PIRException ignore)
@@ -108,7 +109,7 @@ public class PaillierTest
 
     try
     {
-      Paillier paillier = new Paillier(BigInteger.valueOf(7), BigInteger.valueOf(7), 128);
+      Paillier paillier = PaillierBridge.newPaillier(BigInteger.valueOf(7), BigInteger.valueOf(7), 128);
       assertNotNull(paillier);
       fail("Paillier constructor did not throw PIRException for p = q");
     } catch (PIRException ignore)
@@ -116,7 +117,7 @@ public class PaillierTest
 
     try
     {
-      Paillier paillier = new Paillier(BigInteger.valueOf(8), BigInteger.valueOf(7), 128);
+      Paillier paillier = PaillierBridge.newPaillier(BigInteger.valueOf(8), BigInteger.valueOf(7), 128);
       assertNotNull(paillier);
       fail("Paillier constructor did not throw PIRException for p not prime");
     } catch (PIRException ignore)
@@ -124,7 +125,7 @@ public class PaillierTest
 
     try
     {
-      Paillier paillier = new Paillier(BigInteger.valueOf(7), BigInteger.valueOf(10), 128);
+      Paillier paillier = PaillierBridge.newPaillier(BigInteger.valueOf(7), BigInteger.valueOf(10), 128);
       assertNotNull(paillier);
       fail("Paillier constructor did not throw PIRException for q not prime");
     } catch (PIRException ignore)
@@ -141,7 +142,7 @@ public class PaillierTest
 
     try
     {
-      Paillier pailler = new Paillier(p, q, bitLength);
+      Paillier pailler = PaillierBridge.newPaillier(p, q, bitLength);
       BigInteger encM1 = pailler.encrypt(N);
       assertNotNull(encM1);
       fail("Paillier encryption did not throw PIRException for message m = N");
@@ -150,7 +151,7 @@ public class PaillierTest
 
     try
     {
-      Paillier pailler = new Paillier(p, q, bitLength);
+      Paillier pailler = PaillierBridge.newPaillier(p, q, bitLength);
       BigInteger encM1 = pailler.encrypt(N.add(BigInteger.TEN));
       assertNotNull(encM1);
       fail("Paillier encryption did not throw PIRException for message m > N");
@@ -179,7 +180,7 @@ public class PaillierTest
   {
     logger.info("Starting testPaillierGivenAllParameters: ");
 
-    Paillier pailler = new Paillier(p, q, bitLength);
+    Paillier pailler = PaillierBridge.newPaillier(p, q, bitLength);
 
     assertEquals(pailler.getN(), N);
     assertEquals(pailler.getLambdaN(), lambdaN);


### PR DESCRIPTION
For discussion:
Paillier currently exposes a public constructor that is only for testing.  This is one way to make it default visibility (package private) to hide it as a published API, but make it available for testing via a bridge.

I hope we agree not to expose methods only designed for testing as public API.
Is there a better way to do this?