### PR TITLE
Drop use of secondary set to track hash collisions.

### DIFF
--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQuery.java
@@ -21,10 +21,8 @@ package org.apache.pirk.querier.wideskies.encrypt;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
@@ -163,7 +161,6 @@ public class EncryptQuery
     String hashKey = queryInfo.getHashKey();
     int keyCounter = 0;
     int numSelectors = selectors.size();
-    Set<Integer> hashes = new HashSet<>(numSelectors);
     Map<Integer,Integer> selectorQueryVecMapping = new HashMap<>(numSelectors);
 
     for (int index = 0; index < numSelectors; index++)
@@ -172,16 +169,14 @@ public class EncryptQuery
       int hash = KeyedHash.hash(hashKey, queryInfo.getHashBitSize(), selector);
 
       // All keyed hashes of the selectors must be unique
-      if (hashes.add(hash))
+      if (selectorQueryVecMapping.put(hash, index) == null)
       {
         // The hash is unique
-        selectorQueryVecMapping.put(hash, index);
         logger.debug("index = " + index + "selector = " + selector + " hash = " + hash);
       }
       else
       {
         // Hash collision
-        hashes.clear();
         selectorQueryVecMapping.clear();
         hashKey = queryInfo.getHashKey() + ++keyCounter;
         logger.debug("index = " + index + "selector = " + selector + " hash collision = " + hash + " new key = " + hashKey);

--- a/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQueryTask.java
+++ b/src/main/java/org/apache/pirk/querier/wideskies/encrypt/EncryptQueryTask.java
@@ -66,7 +66,7 @@ final class EncryptQueryTask implements Callable<SortedMap<Integer,BigInteger>>
       BigInteger valToEnc = (selectorNum == null) ? BigInteger.ZERO : (BigInteger.valueOf(2)).pow(selectorNum * dataPartitionBitSize);
       BigInteger encVal = paillier.encrypt(valToEnc);
       encryptedValues.put(i, encVal);
-      logger.debug("selectorNum = " + selectorNum + " valToEnc = " + valToEnc + " envVal = " + encVal);
+      logger.debug("selectorNum = " + selectorNum + " valToEnc = " + valToEnc + " encVal = " + encVal);
     }
 
     return encryptedValues;

--- a/src/main/java/org/apache/pirk/schema/data/DataSchema.java
+++ b/src/main/java/org/apache/pirk/schema/data/DataSchema.java
@@ -143,7 +143,7 @@ public class DataSchema implements Serializable
    * @param elementName
    *          the name of the element whose partitioner is required.
    * @return the data partitioner, or <code>null</code> if the element does not exist.
-   * @throws PIRExcpetion
+   * @throws PIRException
    *           if the partitioner cannot be instantiated.
    * @see DataSchema#getPartitionerInstance(String)
    */


### PR DESCRIPTION
 - Hash collisions can be detected via the key set of ```selectorQueryVecMapping```, so no need for separate ```hashes``` set.
 - Fixed some minor javadoc typos.