### PR TITLE
[Pirk-65] Debug Logging Not Working within Distributed Applications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,18 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j2.version}</version>
         </dependency>

--- a/src/main/java/org/apache/pirk/utils/LogUtils.java
+++ b/src/main/java/org/apache/pirk/utils/LogUtils.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.pirk.utils;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.log4j.PropertyConfigurator;
+
+/**
+ * Class to update logging in new environments like hadoop or yarn.
+ * Useful for when you want to change the log levels in hadoop or yarn, which
+ * by default would otherwise ignore our logging settings.
+ */
+public class LogUtils
+{
+
+  private static final Logger logger = LoggerFactory.getLogger(LogUtils.class);
+
+//  static
+//  {
+//    reassertLogProperties();
+//  }
+
+  public static void reassertLogProperties()
+  {
+    Properties props = new Properties();
+    try
+    {
+      String log4jFilename = SystemConfiguration.getProperty("log4jPropertiesFile");
+      if (log4jFilename == null)
+      {
+        logger.error("log4jPropertiesFile property not found during LogUtils initialization.");
+      }
+      else
+      {
+        InputStream stream = SystemConfiguration.class.getClassLoader().getResourceAsStream(log4jFilename);
+        if (stream != null)
+        {
+          logger.info("Loading log4j properties file: '" + log4jFilename + "'");
+          props.load(stream);
+          PropertyConfigurator.configure(props);
+          stream.close();
+        }
+        else
+        {
+          logger.info("log4j properties file not found: '" + log4jFilename + "'");
+        }
+      }
+    } catch (Exception e)
+    {
+      logger.error("Exception occured configuring the log4j system: " + e.toString());
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/org/apache/pirk/utils/SystemConfiguration.java
+++ b/src/main/java/org/apache/pirk/utils/SystemConfiguration.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.pirk.utils.LogUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +59,10 @@ public class SystemConfiguration
 
   private static final String LOCAL_PROPERTIES_DIR = "local.pirk.properties.dir";
 
+  // The below cannot be named "log4j.properties" as that name will seek to
+  // hadoop's similarly named file and not our own.
+  private static final String LOG_PROPERTIES_FILE = "mylog4j.properties";
+
   static
   {
     initialize();
@@ -76,6 +81,10 @@ public class SystemConfiguration
 
     // Try to load the local properties files, if they exists
     loadPropsFromDir(getProperty(LOCAL_PROPERTIES_DIR));
+
+    // Try to reassert our own log properties
+    // Needed to ensure that we can change log levels in hadoop/mapreduce.
+    LogUtils.reassertLogProperties();
   }
 
   /**

--- a/src/main/java/org/apache/pirk/utils/SystemConfiguration.java
+++ b/src/main/java/org/apache/pirk/utils/SystemConfiguration.java
@@ -59,10 +59,6 @@ public class SystemConfiguration
 
   private static final String LOCAL_PROPERTIES_DIR = "local.pirk.properties.dir";
 
-  // The below cannot be named "log4j.properties" as that name will seek to
-  // hadoop's similarly named file and not our own.
-  private static final String LOG_PROPERTIES_FILE = "mylog4j.properties";
-
   static
   {
     initialize();

--- a/src/main/resources/pirk.properties
+++ b/src/main/resources/pirk.properties
@@ -25,6 +25,8 @@
 #hadoop jar command
 local.pirk.properties.dir=/root/
 
+log4jPropertiesFile=mylog4j.properties
+
 ##
 ##Spark path for SparkLauncher
 ##

--- a/src/main/resources/pirk.properties
+++ b/src/main/resources/pirk.properties
@@ -25,7 +25,7 @@
 #hadoop jar command
 local.pirk.properties.dir=/root/
 
-log4jPropertiesFile=mylog4j.properties
+log4jPropertiesFile=pirklog4j.properties
 
 ##
 ##Spark path for SparkLauncher

--- a/src/main/resources/pirklog4j.properties
+++ b/src/main/resources/pirklog4j.properties
@@ -1,0 +1,59 @@
+###############################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+###############################################################################
+# Pirk Log4j Properties file
+
+# Logging levels in order of verboseness:  trace, debug, info, warn, error, fatal
+log4j.rootLogger=info, stdout, rolling
+log4j.logger.org.apache.pirk=debug
+log4j.logger.org.apache.pirk.test.distributed=debug
+#log4j.rootLogger=debug, stdout, rolling
+#log4j.rootLogger=trace, debug, info, stdout, rolling
+#log4j.rootLogger=debug, info, stdout, rolling
+
+# Example of adding a specific package/class at a different
+#log4j.category.responder.wideskies=debug
+
+
+# BEGIN APPENDER: CONSOLE APPENDER (stdout)
+#  first:  type of appender (fully qualified class name)
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+
+#  second: Any configuration information needed for that appender.
+#    Many appenders require a layout.
+# log4j.appender.stdout.layout=org.apache.log4j.SimpleLayout
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+# Pattern to output the caller's file name and line number.
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] %d (%F:%L) - %m%n
+
+
+# BEGIN APPENDER: ROLLING FILE APPENDER (rolling)
+#  first:  type of appender (fully qualified class name)
+log4j.appender.rolling=org.apache.log4j.RollingFileAppender
+log4j.appender.rolling.File=./logs/aip.log
+log4j.appender.rolling.MaxFileSize=1MB
+#  number of backups to keep
+log4j.appender.rolling.MaxBackupIndex=2
+
+log4j.appender.rolling.layout=org.apache.log4j.PatternLayout
+log4j.appender.rolling.layout.ConversionPattern=%d %-5p %-17c{2} %3x - %m%n
+
+log4j.logger.org.apache.zookeeper=error
+log4j.logger.org.apache.hadoop.hbase=debug
+log4j.logger.org.apache.hadoop.hbase.zookeeper=warn
+

--- a/src/main/resources/pirklog4j.properties
+++ b/src/main/resources/pirklog4j.properties
@@ -21,7 +21,6 @@
 # Logging levels in order of verboseness:  trace, debug, info, warn, error, fatal
 log4j.rootLogger=info, stdout, rolling
 log4j.logger.org.apache.pirk=debug
-log4j.logger.org.apache.pirk.test.distributed=debug
 #log4j.rootLogger=debug, stdout, rolling
 #log4j.rootLogger=trace, debug, info, stdout, rolling
 #log4j.rootLogger=debug, info, stdout, rolling


### PR DESCRIPTION
Fixes distributed logging.

In order to do so, we need to use the log4j2-1.2 bridge, and reassert our own log4j properties after hadoop/yarn start. We also need to make sure that our log4j1-style properties file is *not* named log4j.properties, as that name is eaten by hadoop because hadoop has a file of the same name earlier in the classpath than our properties file.