### PR TITLE
Revert PIRK-35 and update some dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <scala.version>2.10.4</scala.version>
-        <jmh.version>1.13</jmh.version>
+        <jmh.version>1.15</jmh.version>
         <benchmarkjar.name>benchmarks</benchmarkjar.name>
         <javac.target>1.8</javac.target>
         <slf4j.version>1.7.21</slf4j.version>
@@ -86,13 +86,11 @@
         <junit.version>4.12</junit.version>
         <log4j.configuration>log4j2.xml</log4j.configuration>
         <hadoop.version>2.7.3</hadoop.version>
-        <spark.version>2.0.0</spark.version>
-        <elasticsearch.version>2.3.4</elasticsearch.version>
+        <spark.version>2.0.1</spark.version>
+        <elasticsearch.version>2.4.0</elasticsearch.version>
         <storm.version>1.0.1</storm.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <spark-streaming.version>2.0.0</spark-streaming.version>
-        <pirk.forkCount>1C</pirk.forkCount>
-        <pirk.reuseForks>true</pirk.reuseForks>
+        <spark-streaming.version>2.0.1</spark-streaming.version>
     </properties>
 
     <dependencies>
@@ -427,7 +425,7 @@
                         <dependency>
                             <groupId>org.apache.maven.doxia</groupId>
                             <artifactId>doxia-core</artifactId>
-                            <version>1.6</version>
+                            <version>1.7</version>
                             <exclusions>
                                 <exclusion>
                                     <groupId>xerces</groupId>
@@ -475,14 +473,14 @@
                 <plugin>
                     <groupId>org.eluder.coveralls</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
-                    <version>4.2.0</version>
+                    <version>4.3.0</version>
                 </plugin>
 
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18</version>
+                    <version>2.19.1</version>
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <argLine combine.children="append">-Xmx1G


### PR DESCRIPTION
 - Roll back the changes to PIRK-35 Execute Tests in Parallel to improve stability.
 - Update Pirk's dependency versions for JMH, Spark, Spark Streaming, Elastic Search, Doxia, Coveralls, and Surefire.
 - Due to compile/runtime issues, no updates to available later versions of Scala, Log4j, Storm, and Kafka.