### PR TITLE
[website] Update IBM Bluemix instructions, and fix typo.

### DIFF
--- a/cloud_instructions.md
+++ b/cloud_instructions.md
@@ -148,8 +148,9 @@ If you want to SSH in and set up a SOCKS proxy to access the [web interfaces](ht
 3. Click "Open" to see the cluster list, and from there create a new cluster,
 e.g.
   * `cluster name =` *`test-cluster`*, `user name = pirk`, `password =` *`password`*.
-  * In the Configuration section increase the number of data nodes to 5 (the maximum number available on the basic plan).
-  * Scroll down and select "Spark" as an optional component.
+  * Increase the number of data nodes to 5 (the maximum number available on the basic plan).
+  * Change the "IBM Open Platform Version" to "IOP 4.3 Technical Preview" (required for Spark 2.0).
+  * Select "Spark2" as an optional component.
   * Click "Create".
 4. Select the test cluster from the Cluster List and take note of the SSH host name,
 e.g. `bi-hadoop-prod-4174.bi.services.us-south.bluemix.net`

--- a/for_developers.md
+++ b/for_developers.md
@@ -94,7 +94,7 @@ To run all of the distributed functional tests on a cluster, the following ‘ha
 
 Specific distributed test suites may be run via providing corresponding command line options. The available options are given by the following command:
 
-	hadoop jar <pirkJar> org.apache.pirk.test.distributed.DistributedTestDriver —help
+	hadoop jar <pirkJar> org.apache.pirk.test.distributed.DistributedTestDriver --help
 
 The Pirk functional tests using Spark run via utilizing the [SparkLauncher](https://spark.apache.org/docs/1.6.0/api/java/org/apache/spark/launcher/package-summary.html) via the ‘hadoop jar’ command (not by directly running with ’spark-submit’). 
 To run successfully, the ‘spark.home’ property must be set correctly in the ‘pirk.properties’ file; ’spark-home’ is the directory containing ’bin/spark-submit’.

--- a/index.md
+++ b/index.md
@@ -83,7 +83,7 @@ If you are a Developer, please check out the [For Developers]({{ site.baseurl }}
 
 ## Community
 
-Please check out our [community]({{ site.baseurl }}/get_involved) section.
+Please check out our [community]({{ site.baseurl }}/get_involved_pirk) section.
 
 ## Roadmap
 


### PR DESCRIPTION
 - Updating cloud instructions to show extra step required for Spark 2.0 support.
 - Fixing special character to ascii hyphens for dist test help command.