### PR TITLE
Correct the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ cache:
   directories:
     - $HOME/.m2
 
-install: mvn clean install
+script: mvn clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,7 @@ language: java
 os: linux
 jdk: oraclejdk8
 
-# before_install is used to provide a workaround for buffer overflow issues with OpenJDK versions of java as per:
-#    https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165135711
-before_install:
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-
-  - wget http://apache.claz.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-  - tar zxvf apache-maven-3.3.9-bin.tar.gz
-  - chmod +x apache-maven-3.3.9/bin/mvn
-  - export M2_HOME=$PWD/apache-maven-3.3.9
-  - export PATH=$PWD/apache-maven-3.3.9/bin:${PATH}
-  - hash -r
+sudo: false
 
 cache:
   directories:


### PR DESCRIPTION
The step that builds pirk is incorrectly in the install phase (which [Travis CI documentation](https://docs.travis-ci.com/user/customizing-the-build) says is to "install any dependencies required"). The script phase is to "run the build script" which is what was happening in the install phase. 

Right now the same tests run twice which increases build time for no benefit. To verify this, look at [this build log](https://s3.amazonaws.com/archive.travis-ci.org/jobs/174076031/log.txt) and search for `T E S T S`.